### PR TITLE
Use intermediary meshes for transferring data during mesh movement

### DIFF
--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -139,12 +139,17 @@ class AdaptiveProblemBase(object):
         raise NotImplementedError("To be implemented in derived class")
 
     def create_intermediary_spaces(self):
-        # TODO: doc
+        """
+        Create a copy of each mesh and define function spaces and solution fields upon it.
+
+        This functionality is used for mesh movement driven by solving Monge-Ampere type equations.
+        """
         if self.op.approach != 'monge_ampere':
             return
-        self.intermediary_meshes = [Mesh(mesh.coordinates.copy(deepcopy=True)) for mesh in self.meshes]
-        intermediary_spaces = [FunctionSpace(V.mesh(), V.ufl_element()) for V in self.V]
-        self.intermediary_solutions = [Function(fs) for fs in intermediary_spaces]
+        mesh_copies = [Mesh(mesh.coordinates.copy(deepcopy=True)) for mesh in self.meshes]
+        spaces = [FunctionSpace(mesh, self.finite_element) for mesh in mesh_copies]
+        self.intermediary_meshes = mesh_copies
+        self.intermediary_solutions = [Function(space) for space in spaces]
 
     def create_function_spaces(self):
         raise NotImplementedError("To be implemented in derived class")

--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -225,6 +225,7 @@ class AdaptiveProblemBase(object):
         self.project(self.adj_solutions, i, j)
 
     def project_fields(self, fields, i):
+        """Project a dictionary of fields into corresponding spaces defined on mesh i."""
         for f in fields:
             if isinstance(fields[f], Function):
                 self.fields[i].project(fields[f])
@@ -248,10 +249,22 @@ class AdaptiveProblemBase(object):
             self.project_adjoint_solution(i+1, i)
 
     def project_to_intermediary_mesh(self, i):
+        """
+        Project solution fields from mesh i into corresponding function spaces defined on
+        intermediary mesh i.
+
+        This function is designed for use under Monge-Ampere type mesh movement methods.
+        """
         for f, f_int in zip(self.fwd_solutions[i].split(), self.intermediary_solutions[i].split()):
             f_int.project(f)
 
     def copy_data_from_intermediary_mesh(self, i):
+        """
+        Copy the data from intermediary solution field i into the corresponding solution field
+        on the physical mesh.
+
+        This function is designed for use under Monge-Ampere type mesh movement methods.
+        """
         for f, f_int in zip(self.fwd_solutions[i].split(), self.intermediary_solutions[i].split()):
             f.dat.data[:] = f_int.dat.data
 
@@ -358,11 +371,21 @@ class AdaptiveProblemBase(object):
             raise ValueError("Approach '{:s}' not recognised".format(self.approach))
 
     def get_qoi_kernels(self, i):
+        """
+        Define kernels associated with the quantity of interest from the corresponding
+        `set_qoi_kernel` method of the `Options` parameter class.
+        """
         self.op.set_qoi_kernel(self, i)
 
     # --- Mesh movement
 
     def set_monitor_functions(self, monitors):
+        """
+        Pass a monitor function to each mesh, thereby defining a `MeshMover` object which drives
+        r-adaptation.
+
+        NOTE: The monitor function should be a function with one argument, namely the mesh.
+        """
         from adapt_utils.adapt.r import MeshMover
 
         # Sanitise input

--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -479,19 +479,31 @@ class AdaptiveProblemBase(object):
             raise ValueError("No monitor function was provided. Use `set_monitor_functions`.")
 
         # Compute new physical mesh coordinates
+        self.op.print_debug("MESH MOVEMENT: Establishing mesh transformation...")
         self.mesh_movers[i].adapt()
+        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Update intermediary mesh coordinates
+        self.op.print_debug("MESH MOVEMENT: Updating intermediary mesh coordinates...")
         self.intermediary_meshes[i].coordinates.dat.data[:] = self.mesh_movers[i].x.dat.data
+        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Project a copy of the current solution onto mesh defined on new coordinates
+        self.op.print_debug("MESH MOVEMENT: Projecting solutions onto intermediary mesh...")
         self.project_to_intermediary_mesh(i)
+        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Update physical mesh coordinates
+        self.op.print_debug("MESH MOVEMENT: Updating physical mesh coordinates...")
         self.meshes[i].coordinates.dat.data[:] = self.intermediary_meshes[i].coordinates.dat.data
+        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Copy over projected solution data
+        self.op.print_debug("MESH MOVEMENT: Transferring solution data from intermediary mesh...")
         self.copy_data_from_intermediary_mesh(i)  # FIXME: Needs annotation
+        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Re-interpolate fields
+        self.op.print_debug("MESH MOVEMENT: Re-interpolating fields...")
         self.set_fields()
+        self.op.print_debug("MESH MOVEMENT: Done!")

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -459,22 +459,29 @@ class AdaptiveProblem(AdaptiveProblemBase):
         if self.op.solve_exner:
             self.intermediary_solutions_bathymetry[i].project(self.fwd_solutions_bathymetry[i])
 
-        def debug(a, b):
+        def debug(a, b, name):
             if np.allclose(a, b):
-                print_output("WARNING: Is the intermediary solution just copied???")
+                print_output("WARNING: Is the intermediary {:s} solution just copied?".format(name))
 
         if self.op.debug:
-            debug(self.fwd_solutions[i].dat.data[0], self.intermediary_solutions[i].dat.data[0])
-            debug(self.fwd_solutions[i].dat.data[1], self.intermediary_solutions[i].dat.data[1])
+            debug(self.fwd_solutions[i].dat.data[0],
+                  self.intermediary_solutions[i].dat.data[0],
+                  "velocity")
+            debug(self.fwd_solutions[i].dat.data[1],
+                  self.intermediary_solutions[i].dat.data[1],
+                  "elevation")
             if self.op.solve_tracer:
                 debug(self.fwd_solutions_tracer[i].dat.data,
-                      self.intermediary_solutions_tracer[i].dat.data)
+                      self.intermediary_solutions_tracer[i].dat.data,
+                      "tracer")
             if self.op.solve_sediment:
                 debug(self.fwd_solutions_sediment[i].dat.data,
-                      self.intermediary_solutions_sediment[i].dat.data)
+                      self.intermediary_solutions_sediment[i].dat.data,
+                      "sediment")
             if self.op.solve_exner:
                 debug(self.fwd_solutions_bathymetry[i].dat.data,
-                      self.intermediary_solutions_bathymetry[i].dat.data)
+                      self.intermediary_solutions_bathymetry[i].dat.data,
+                      "bathymetry")
 
     def copy_data_from_intermediary_mesh(self, i):
         super(AdaptiveProblem, self).copy_data_from_intermediary_mesh(i)

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -458,6 +458,23 @@ class AdaptiveProblem(AdaptiveProblemBase):
         if self.op.solve_exner:
             self.intermediary_solutions_bathymetry[i].project(self.fwd_solutions_bathymetry[i])
 
+        def debug(a, b):
+            if np.allclose(a, b):
+                print_output("WARNING: Is the intermediary solution just copied???")
+
+        if self.op.debug:
+            debug(self.fwd_solutions[i].dat.data[0], self.intermediary_solutions[i].dat.data[0])
+            debug(self.fwd_solutions[i].dat.data[1], self.intermediary_solutions[i].dat.data[1])
+            if self.op.solve_tracer:
+                debug(self.fwd_solutions_tracer[i].dat.data,
+                      self.intermediary_solutions_tracer[i].dat.data)
+            if self.op.solve_sediment:
+                debug(self.fwd_solutions_sediment[i].dat.data,
+                      self.intermediary_solutions_sediment[i].dat.data)
+            if self.op.solve_exner:
+                debug(self.fwd_solutions_bathymetry[i].dat.data,
+                      self.intermediary_solutions_bathymetry[i].dat.data)
+
     def copy_data_from_intermediary_mesh(self, i):
         super(AdaptiveProblem, self).copy_data_from_intermediary_mesh(i)
         if self.op.solve_tracer:

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1744,7 +1744,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
         self.meshes[i].coordinates.dat.data[:] = self.intermediary_meshes[i].coordinates.dat.data[:]
 
         # Update physical mesh and solution fields defined on it
-        self.meshes[i].coordinates.assign(self.mesh_movers[i].x)
         for int_sol, sol in zip(intermediary_solutions.split(), solutions.split()):
             sol.dat.data[:] = int_sol.dat.data  # FIXME: Need annotation
 

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -189,15 +189,16 @@ class AdaptiveProblem(AdaptiveProblemBase):
         super(AdaptiveProblem, self).create_intermediary_spaces()
         if self.op.approach != 'monge_ampere':
             return
+        mesh_copies = self.intermediary_meshes
         if self.op.solve_tracer:
-            intermediary_spaces = [FunctionSpace(Q.mesh(), Q.ufl_element()) for Q in self.Q]
-            self.intermediary_solutions_tracer = [Function(fs) for fs in intermediary_spaces]
+            spaces = [FunctionSpace(mesh, self.finite_element_tracer) for mesh in mesh_copies]
+            self.intermediary_solutions_tracer = [Function(space) for space in spaces]
         if self.op.solve_sediment:
-            intermediary_spaces = [FunctionSpace(Q.mesh(), Q.ufl_element()) for Q in self.Q]
-            self.intermediary_solutions_sediment = [Function(fs) for fs in intermediary_spaces]
+            spaces = [FunctionSpace(mesh, self.finite_element_sediment) for mesh in mesh_copies]
+            self.intermediary_solutions_sediment = [Function(space) for space in spaces]
         if self.op.solve_exner:
-            intermediary_spaces = [FunctionSpace(W.mesh(), W.ufl_element()) for W in self.W]
-            self.intermediary_solutions_bathymetry = [Function(fs) for fs in intermediary_spaces]
+            spaces = [FunctionSpace(mesh, self.finite_element_bathymetry) for mesh in mesh_copies]
+            self.intermediary_solutions_bathymetry = [Function(space) for space in spaces]
 
     def create_solutions(self):
         """

--- a/unsteady/test_cases/beach_wall/run_fixed_mesh.py
+++ b/unsteady/test_cases/beach_wall/run_fixed_mesh.py
@@ -69,6 +69,9 @@ kwargs = {
     'plot_pvd': True,
     'input_dir': inputdir,
     'output_dir': outputdir,
+
+    # Debugging
+    'debug': True,
 }
 
 op = BeachOptions(**kwargs)

--- a/unsteady/test_cases/beach_wall/run_moving_mesh_bath.py
+++ b/unsteady/test_cases/beach_wall/run_moving_mesh_bath.py
@@ -84,10 +84,12 @@ kwargs = {
     'plot_pvd': True,
     'input_dir': inputdir,
     'output_dir': outputdir,
+
+    # Debugging
+    'debug': True,
 }
 
 op = BeachOptions(**kwargs)
-assert op.num_meshes == 1
 swp = AdaptiveProblem(op)
 # swp.shallow_water_options[0]['mesh_velocity'] = swp.mesh_velocities[0]
 swp.shallow_water_options[0]['mesh_velocity'] = None


### PR DESCRIPTION
Aims to address shift issues in the `beach` test case. This PR introduces intermediary meshes and solutions to transfer data to during mesh movement. Here is the final export from the `beach_wall` test case, comparing the fixed mesh solution (grid not visible) against the Monge-Ampere moving mesh solution (grid visible).

![final_export__fixed_vs_moving](https://user-images.githubusercontent.com/22053413/89533208-f91d7d80-d7ea-11ea-837b-684ce9d77c36.png)

From Slack discussion:
"The fact that there isn't a uniform shift is encouraging, because that would suggest the interpolation is wrong and data is just getting copied (as before). I think the moving mesh (the one where the grid is visible) resembles the fixed mesh one closely enough here that we might be witnessing the effect of: (a) interpolation error; (b) improved accuracy of mesh movement; or (c) both."