### PR TITLE
Update time dependent mesh adaptation

### DIFF
--- a/adapt/adaptation.py
+++ b/adapt/adaptation.py
@@ -7,20 +7,13 @@ import warnings
 
 from adapt_utils.adapt.kernels import *
 from adapt_utils.options import Options
-from adapt_utils.misc import suppress_output
 
 
 __all__ = ["pragmatic_adapt", "AdaptiveMesh"]
 
 
-def pragmatic_adapt(mesh, M, op=Options):
-    debug_full = op.debug and op.debug_mode == 'fill'
-    if not debug_full:
-        with suppress_output():
-            out = adapt(mesh, M)
-    else:
-        out = adapt(mesh, M)
-    return out
+def pragmatic_adapt(mesh, M):
+    return adapt(mesh, M)
 
 
 class AdaptiveMesh():

--- a/adapt/adaptation.py
+++ b/adapt/adaptation.py
@@ -14,7 +14,8 @@ __all__ = ["pragmatic_adapt", "AdaptiveMesh"]
 
 
 def pragmatic_adapt(mesh, M, op=Options):
-    if not op.debug:
+    debug_full = op.debug and op.debug_mode == 'fill'
+    if not debug_full:
         with suppress_output():
             out = adapt(mesh, M)
     else:

--- a/adapt/adaptation.py
+++ b/adapt/adaptation.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import warnings
 
 from adapt_utils.adapt.kernels import *
+from adapt_utils.io import save_mesh, load_mesh
 from adapt_utils.options import Options
 
 
@@ -119,29 +120,29 @@ class AdaptiveMesh():
         if savefig:
             plt.savefig(os.path.join(self.op.di, 'scaled_jacobian.pdf'))
 
-    def save_plex(self, filename):
+    def save_mesh(self, *args):
         """
-        Save mesh in DMPlex format.
-        """
-        viewer = PETSc.Viewer().createHDF5(filename, 'w')
-        try:
-            viewer(self.mesh._topology_dm)
-        except AttributeError:
-            viewer(self.mesh._plex)  # backwards compatibility
+        Save mesh to DMPlex format.
 
-    def load_plex(self, filename):
+        :arg fname: file name (without '.h5' extension).
+        :arg fpath: directory to store the file.
+        """
+        save_mesh(self.mesh, *args)
+
+    def load_mesh(self, *args):
         """
         Load mesh from DMPlex format. The `MeshHierarchy` is reinstated.
+
+        :arg fname: file name (without '.h5' extension).
+        :arg fpath: directory where the file is stored.
         """
-        newplex = PETSc.DMPlex().create()
-        newplex.createFromFile(filename)
-        self.__init__(Mesh(newplex), levels=self.levels)
+        self.__init__(load_mesh(*args), levels=self.levels)
 
     def pragmatic_adapt(self, metric):
         """
         Adapt mesh using a specified metric. The `MeshHierarchy` is reinstated.
         """
-        self.__init__(adapt(self.mesh, metric), levels=self.levels)
+        self.__init__(pragmatic_adapt(self.mesh, metric), levels=self.levels)
 
     def get_edge_lengths(self):
         """

--- a/adapt/metric.py
+++ b/adapt/metric.py
@@ -59,19 +59,16 @@ def steady_metric(f=None, H=None, projector=None, **kwargs):
     op.print_debug("METRIC: Constructing metric from Hessian...")
     kernel = eigen_kernel(metric_from_hessian, dim)
     op2.par_loop(kernel, V.node_set, M.dat(op2.RW), H.dat(op2.READ))
-    op.print_debug("METRIC: Done!")
 
     # Apply Lp normalisation
     if kwargs.get('normalise'):
         op.print_debug("METRIC: Normalising metric in space...")
         space_normalise(M, noscale=kwargs.get('noscale'), f=f, op=op)
-        op.print_debug("METRIC: Done!")
 
     # Enforce maximum/minimum element sizes and anisotropy
     if kwargs.get('enforce_constraints'):
         op.print_debug("METRIC: Enforcing elemental constraints...")
         enforce_element_constraints(M, op=op)
-        op.print_debug("METRIC: Done!")
 
     return M
 
@@ -115,7 +112,6 @@ def space_time_normalise(hessians, timestep_integrals=None, enforce_constraints=
             glob_norm *= pow(integral, 1/p)
     else:
         raise ValueError("Normalisation approach {:s} not recognised.".format(op.normalisation))
-    op.print_debug("METRIC: Done!")
     op.print_debug("METRIC: Target space-time complexity = {:.4e}".format(N_st))
     op.print_debug("METRIC: Global normalisation factor = {:.4e}".format(glob_norm))
 
@@ -132,8 +128,6 @@ def space_time_normalise(hessians, timestep_integrals=None, enforce_constraints=
         if enforce_constraints:
             op.print_debug("METRIC: Enforcing size and ansisotropy constraints...")
             enforce_element_constraints(H, op=op)
-            op.print_debug("METRIC: Done!")
-    op.print_debug("METRIC: Done!")
 
 
 def space_normalise(M, f=None, **kwargs):
@@ -294,7 +288,6 @@ def isotropic_metric(f, **kwargs):
     op.print_debug("METRIC: Constructing isotropic metric...")
     M_diag = project(max_value(abs(f), 1e-10), V)
     M_diag.interpolate(abs(M_diag))  # Ensure positivity
-    op.print_debug("METRIC: Done!")
 
     # Normalise
     if kwargs.get('normalise'):
@@ -314,13 +307,11 @@ def isotropic_metric(f, **kwargs):
             if p is not None:
                 M_diag *= pow(assemble(detM*dx), 1/p)
             M_diag *= dim/rescale
-        op.print_debug("METRIC: Done!")
 
     # Enforce maximum/minimum element sizes
     if kwargs.get('enforce_constraints'):
         op.print_debug("METRIC: Enforcing elemental constraints...")
         M_diag = max_value(1/pow(op.h_max, 2), min_value(M_diag, 1/pow(op.h_min, 2)))
-        op.print_debug("METRIC: Done!")
 
     return interpolate(M_diag*Identity(dim), V_ten)
 
@@ -432,13 +423,11 @@ class SteadyHessianMetric():
         kernel = eigen_kernel(metric_from_hessian, self.dim)
         op2.par_loop(kernel, self.fs.node_set, tmp.dat(op2.RW), self.M.dat(op2.READ))
         self.M.assign(tmp)
-        self.op.print_debug("METRIC: Done!")
 
     def normalise(self, noscale=False):
         # TODO: put doc here
         self.op.print_debug("METRIC: Normalising metric in space...")
         space_normalise(self.M, noscale=noscale, op=self.op)  # TODO: put here
-        self.op.print_debug("METRIC: Done!")
 
     def enforce_element_constraints(M, op=Options()):
         """

--- a/case_studies/tohoku/hazard/makefile
+++ b/case_studies/tohoku/hazard/makefile
@@ -42,18 +42,26 @@ fixed_mesh:
 
 hessian:
 	@echo "Solving Tohoku tsunami problem using anisotropic 'hessian' adaptation..."
-	@python3 run_hessian_based.py -dm_plex_prescribed_boundary_labels 200,300 -dm_plex_prescribed_boundary_sizes 10e3,5e3
+	@python3 run_hessian_based.py \
+		-dm_plex_prescribed_boundary_labels 200,300 \
+		-dm_plex_prescribed_boundary_sizes 10e3,5e3
 	@echo "Done!"
 
 dwp:
 	@echo "Solving Tohoku tsunami problem using isotropic 'dual weighted primal' adaptation..."
-	@python3 run_dwp.py -dm_plex_prescribed_boundary_labels 200,300 -dm_plex_prescribed_boundary_sizes 10e3,5e3
+	@python3 run_dwp.py \
+		-dm_plex_prescribed_boundary_labels 200,300 \
+		-dm_plex_prescribed_boundary_sizes 10e3,5e3
 	@echo "Done!"
-# @python3 run_dwp.py -dm_plex_prescribed_boundary_labels 100,200,300 -dm_plex_prescribed_boundary_sizes 100e3,10e3,5e3
+# @python3 run_dwp.py \
+#	  -dm_plex_prescribed_boundary_labels 100,200,300
+#	  -dm_plex_prescribed_boundary_sizes 100e3,10e3,5e3
 
 dwr:
 	@echo "Solving Tohoku tsunami problem using isotropic 'dual weighted residual' adaptation..."
-	@python3 run_dwr.py -dm_plex_prescribed_boundary_labels 200,300 -dm_plex_prescribed_boundary_sizes 10e3,5e3
+	@python3 run_dwr.py \
+		-dm_plex_prescribed_boundary_labels 200,300 \
+		-dm_plex_prescribed_boundary_sizes 10e3,5e3
 	@echo "Done!"
 
 # Cleanup

--- a/case_studies/tohoku/hazard/makefile
+++ b/case_studies/tohoku/hazard/makefile
@@ -6,7 +6,6 @@ all: dir
 dir:
 	@echo "Creating output directory..."
 	@mkdir -p outputs
-	@echo "Done!"
 
 
 # --- Convergence analysis
@@ -14,12 +13,10 @@ dir:
 qmesh_linear:
 	@echo "Running convergence analysis using linear shallow water equations..."
 	@python3 run_qmesh_convergence.py
-	@echo "Done!"
 
 qmesh_nonlinear:
 	@echo "Running convergence analysis using nonlinear shallow water equations..."
 	@python3 run_qmesh_convergence.py -nonlinear 1
-	@echo "Done!"
 
 qmesh: qmesh_linear qmesh_nonlinear
 
@@ -29,7 +26,6 @@ qmesh: qmesh_linear qmesh_nonlinear
 fixed_mesh:
 	@echo "Solving Tohoku tsunami problem on a fixed mesh..."
 	@python3 run_fixed_mesh.py
-	@echo "Done!"
 #
 #  NOTE: We specify different gradation parameters for different boundary segments:
 #    * Artificial open ocean (tag 100): 100 km;
@@ -45,14 +41,12 @@ hessian:
 	@python3 run_hessian_based.py \
 		-dm_plex_prescribed_boundary_labels 200,300 \
 		-dm_plex_prescribed_boundary_sizes 10e3,5e3
-	@echo "Done!"
 
 dwp:
 	@echo "Solving Tohoku tsunami problem using isotropic 'dual weighted primal' adaptation..."
 	@python3 run_dwp.py \
 		-dm_plex_prescribed_boundary_labels 200,300 \
 		-dm_plex_prescribed_boundary_sizes 10e3,5e3
-	@echo "Done!"
 # @python3 run_dwp.py \
 #	  -dm_plex_prescribed_boundary_labels 100,200,300
 #	  -dm_plex_prescribed_boundary_sizes 100e3,10e3,5e3
@@ -62,7 +56,6 @@ dwr:
 	@python3 run_dwr.py \
 		-dm_plex_prescribed_boundary_labels 200,300 \
 		-dm_plex_prescribed_boundary_sizes 10e3,5e3
-	@echo "Done!"
 
 # Cleanup
 
@@ -78,4 +71,3 @@ clean:
 	@rm -rf outputs/dwp/*.vtu
 	@rm -rf outputs/dwr/*.pvd
 	@rm -rf outputs/dwr/*.vtu
-	@echo "Done!"

--- a/case_studies/tohoku/hazard/plot_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/plot_qmesh_convergence.py
@@ -1,26 +1,35 @@
 from thetis import create_directory
 
-import matplotlib.pyplot as plt
-import os
-import numpy as np
-import datetime
 import argparse
+import datetime
+import matplotlib.pyplot as plt
+import numpy as np
+import os
 
-plt.style.use('seaborn-talk')
+from adapt_utils.plotting import *
+
+
+# --- Parse arguments
 
 parser = argparse.ArgumentParser()
 parser.add_argument("dates")
 parser.add_argument("runs")
 args = parser.parse_args()
 
-di = os.path.join(os.path.dirname(__file__), 'outputs/qmesh')
+
+# --- Set parameters
+
+di = os.path.join(os.path.dirname(__file__), 'outputs', 'qmesh')
 dates = args.dates.split(',')
 runs = args.runs.split(',')
 if len(dates) < len(runs):
     dates = [dates[0] for r in runs]
 assert len(dates) == len(runs)
-
 qois_old = None
+
+
+# --- Load data and plot
+
 for date, run in zip(dates, runs):
     filename = os.path.join(di, '-'.join([date, 'run', run]), 'log')
     use = False
@@ -45,10 +54,7 @@ for date, run in zip(dates, runs):
 plt.xlabel("Element count")
 plt.ylabel(r"Quantity of interest, $J(\mathbf{u},\eta)$")
 plt.legend()
-
 date = datetime.date.today()
 date = '{:d}-{:d}-{:d}'.format(date.year, date.month, date.day)
-di = os.path.join(di, '{:s}-runs-{:s}'.format(date, '-'.join([r for r in runs])))
-if not os.path.exists(di):
-    create_directory(di)
+di = create_directory(os.path.join(di, '{:s}-runs-{:s}'.format(date, '-'.join([r for r in runs]))))
 plt.savefig(os.path.join(di, 'qoi_convergence.png'))

--- a/case_studies/tohoku/hazard/run_continuous_adjoint.py
+++ b/case_studies/tohoku/hazard/run_continuous_adjoint.py
@@ -44,11 +44,13 @@ if args.locations is None:  # TODO: Parse as list
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-radius = args.radius or 100.0e+03
+radius = float(args.radius or 100.0e+03)
 plot_pvd = bool(args.plot_pvd or False)
 kwargs = {
+    'approach': 'fixed_mesh',
 
     # Space-time domain
+    'level': int(args.level or 0),
     'num_meshes': int(args.num_meshes or 1),
     'end_time': float(args.end_time or 24*60.0),
 
@@ -64,7 +66,7 @@ kwargs = {
     'wetting_and_drying_alpha': Constant(10.0),
 
     # QoI
-    'start_time': float(args.start_time or 15*60.0),
+    'start_time': float(args.start_time or 0.0),
     'radius': radius,
     'locations': locations,
 
@@ -73,10 +75,8 @@ kwargs = {
     'debug': bool(args.debug or False),
     'debug_mode': args.debug_mode or 'basic',
 }
-level = int(args.level or 0)
 nonlinear = bool(args.nonlinear or False)
-op = TohokuHazardOptions(approach='fixed_mesh', level=level)
-op.update(kwargs)
+op = TohokuHazardOptions(**kwargs)
 
 
 # --- Initialisation

--- a/case_studies/tohoku/hazard/run_continuous_adjoint.py
+++ b/case_studies/tohoku/hazard/run_continuous_adjoint.py
@@ -24,7 +24,7 @@ parser.add_argument("-stabilisation", help="Stabilisation method to use (default
 
 # QoI
 parser.add_argument("-start_time", help="""
-    Start time of period of interest in seconds (default 1440s, i.e. 24mins)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
     Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
     'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')""")
@@ -70,7 +70,7 @@ kwargs = {
     'radius': radius,
     'locations': locations,
 
-    # Misc
+    # I/O and debugging
     'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
     'debug_mode': args.debug_mode or 'basic',

--- a/case_studies/tohoku/hazard/run_continuous_adjoint.py
+++ b/case_studies/tohoku/hazard/run_continuous_adjoint.py
@@ -1,65 +1,85 @@
-from firedrake import project, MeshHierarchy
+from thetis import *
 
 import argparse
+import os
 
+from adapt_utils.case_studies.tohoku.options.hazard_options import TohokuHazardOptions
 from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
-from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
 
+
+# --- Parse arguments
 
 parser = argparse.ArgumentParser(prog="run_continuous_adjoint")
 
 # Space-time domain
-parser.add_argument("-end_time", help="""
-End time of simulation in seconds (default 1440s, i.e. 24mins)""")
+parser.add_argument("-end_time", help="End time of simulation in seconds (default 1440s i.e. 24min)")
 parser.add_argument("-level", help="(Integer) resolution for initial mesh (default 0)")
 parser.add_argument("-num_meshes", help="Number of meshes to consider (for testing, default 1)")
 parser.add_argument("-levels", help="Number of iso-P2 refinements (for testing, default 0)")
 
 # Solver
 parser.add_argument("-family", help="Element family for mixed FE space (default 'dg-cg')")
+parser.add_argument("-nonlinear", help="Toggle nonlinear equations (default False)")
+parser.add_argument("-stabilisation", help="Stabilisation method to use (default None)")
 
 # QoI
 parser.add_argument("-start_time", help="""
-Start time of period of interest in seconds (default 1200s, i.e. 20mins)""")
+    Start time of period of interest in seconds (default 1440s, i.e. 24mins)""")
 parser.add_argument("-locations", help="""
-Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
-'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')""")
-parser.add_argument("-radii", help="Radii of interest, separated by commas (default 100km)")
+    Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
+    'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')""")
+parser.add_argument("-radius", help="Radius of interest (default 100km)")
 
-# Misc
+# I/O and debugging
+parser.add_argument("-plot_pvd", help="Toggle saving output to .pvd")
 parser.add_argument("-debug", help="Print all debugging statements")
-parser.add_argument("-plot_kernel", help="Just plot kernel functions (do not solve equations)")
+parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
+
 args = parser.parse_args()
 
-# Collect locations and radii
-if args.locations is None:
+
+# --- Set parameters
+
+if args.locations is None:  # TODO: Parse as list
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-if args.radii is None:
-    radii = [100.0e+03 for l in locations]
-else:
-    radii = [float(r) for r in args.radii.split(',')]
-if len(locations) != len(radii):
-    msg = "Number of locations ({:d}) and radii ({:d}) do not match."
-    raise ValueError(msg.format(len(locations), len(radii)))
+radius = args.radius or 100.0e+03
+plot_pvd = bool(args.plot_pvd or False)
+kwargs = {
 
-# Set parameters for fixed mesh adjoint run
-op = TohokuOptions(
-    start_time=float(args.start_time or 0.0),
-    end_time=float(args.end_time or 1200.0),
-    family=args.family or 'cg-cg',
-    stabilisation=None,  # TODO: Lax-Friedrichs
-    level=int(args.level or 0),
-    approach='fixed_mesh',
-    plot_pvd=True,
-    debug=bool(args.debug or False),
-    num_meshes=int(args.num_meshes or 1),
-    radii=radii,
-    locations=locations,
-)
-assert op.start_time >= 0.0
-assert op.start_time <= op.end_time
+    # Space-time domain
+    'num_meshes': int(args.num_meshes or 1),
+    'end_time': float(args.end_time or 24*60.0),
+
+    # Physics
+    'bathymetry_cap': 30.0,  # FIXME
+    # 'bathymetry_cap': None,
+
+    # Solver
+    'family': args.family or 'dg-cg',
+    'stabilsation': args.stabilisation,
+    # 'use_wetting_and_drying': True,
+    'use_wetting_and_drying': False,
+    'wetting_and_drying_alpha': Constant(10.0),
+
+    # QoI
+    'start_time': float(args.start_time or 15*60.0),
+    'radius': radius,
+    'locations': locations,
+
+    # Misc
+    'plot_pvd': plot_pvd,
+    'debug': bool(args.debug or False),
+    'debug_mode': args.debug_mode or 'basic',
+}
+level = int(args.level or 0)
+nonlinear = bool(args.nonlinear or False)
+op = TohokuHazardOptions(approach='fixed_mesh', level=level)
+op.update(kwargs)
+
+
+# --- Initialisation
 
 # Wrap mesh(es) in an iso-P2 refined mesh hiearchy and choose the finest level(s)
 levels = int(args.levels or 0)
@@ -67,16 +87,17 @@ base_meshes = [op.default_mesh for i in range(op.num_meshes)]
 hierarchies = [MeshHierarchy(mesh, levels) for mesh in base_meshes]
 meshes = [hierarchy[levels] for hierarchy in hierarchies]
 
-# Setup problem object
-swp = AdaptiveTsunamiProblem(op, meshes=meshes)
 
-# Take a look at the smoothed kernel function(s) *or* solve adjoint equation
-plot_kernels = bool(args.plot_kernel) or False
-if plot_kernels:
+# --- Solve continuous adjoint
+
+swp = AdaptiveTsunamiProblem(op, meshes=meshes, nonlinear=nonlinear)
+if plot_pvd:
+    kernel_file = File(os.path.join(op.di, 'kernel.pvd'))
     for i, P1 in enumerate(swp.P1):
         swp.get_qoi_kernels(i)
-        k_eta_proj = project(swp.kernels[i].split()[1], P1)
-        k_eta_proj.rename("Kernel function for elevation space")
-        swp.indicator_file.write(k_eta_proj)
-else:
-    swp.solve_adjoint()
+        k_u, k_eta = swp.kernels[i].split()
+        kernel = Function(P1, name="QoI kernel")
+        kernel.project(k_eta)
+        kernel_file._topology = None
+        kernel_file.write(kernel)
+swp.solve_adjoint()

--- a/case_studies/tohoku/hazard/run_dwp.py
+++ b/case_studies/tohoku/hazard/run_dwp.py
@@ -5,8 +5,8 @@ import datetime
 import matplotlib.pyplot as plt
 import os
 
-from adapt_utils.swe.tsunami.solver import AdaptiveTsunamiProblem
-from adapt_utils.unsteady.case_studies.tohoku.options.options import TohokuOptions
+from adapt_utils.case_studies.tohoku.options.hazard_options import TohokuHazardOptions
+from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
 
 
 # --- Parse arguments
@@ -124,7 +124,7 @@ for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
 logstr += "    {:34s}: {:}\n".format('nonlinear', nonlinear)
 print_output(logstr + 80*'*' + '\n')
-op = TohokuOptions(**kwargs)
+op = TohokuHazardOptions(**kwargs)
 
 
 # --- Solve

--- a/case_studies/tohoku/hazard/run_dwp.py
+++ b/case_studies/tohoku/hazard/run_dwp.py
@@ -94,6 +94,7 @@ kwargs = {
     # Solver
     'family': family,
     'stabilsation': stabilisation,
+    'use_wetting_and_drying': False,
 
     # QoI
     'start_time': float(args.start_time or 0.0),
@@ -121,6 +122,7 @@ assert 0.0 <= kwargs['start_time'] <= kwargs['end_time']
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
+logstr += "    {:34s}: {:}\n".format('nonlinear', nonlinear)
 print_output(logstr + 80*'*' + '\n')
 op = TohokuOptions(**kwargs)
 

--- a/case_studies/tohoku/hazard/run_dwp.py
+++ b/case_studies/tohoku/hazard/run_dwp.py
@@ -2,10 +2,14 @@ from thetis import *
 
 import argparse
 import datetime
+import matplotlib.pyplot as plt
+import os
 
-from adapt_utils.unsteady.case_studies.tohoku.options.options import TohokuOptions
 from adapt_utils.swe.tsunami.solver import AdaptiveTsunamiProblem
+from adapt_utils.unsteady.case_studies.tohoku.options.options import TohokuOptions
 
+
+# --- Parse arguments
 
 parser = argparse.ArgumentParser(prog="run_dwp")
 
@@ -16,6 +20,8 @@ parser.add_argument("-num_meshes", help="Number of meshes to consider (default 1
 
 # Solver
 parser.add_argument("-family", help="Element family for mixed FE space (default cg-cg)")
+parser.add_argument("-nonlinear", help="Toggle nonlinear equations (default False)")
+parser.add_argument("-stabilisation", help="Stabilisation method to use (default None)")
 
 # Mesh adaptation
 parser.add_argument("-norm_order", help="p for Lp normalisation (default 1)")
@@ -31,36 +37,54 @@ parser.add_argument("-qoi_rtol", help="Relative tolerance for quantity of intere
 
 # QoI
 parser.add_argument("-start_time", help="""
-Start time of period of interest (default 1200s i.e. 20mins)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
-Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
-'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
-""")
-parser.add_argument("-radii", help="Radii of interest, separated by commas (default 100km)")
+    Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
+    'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
+    """)
+parser.add_argument("-radius", help="Radius of interest (default 100km)")
 
-# Misc
+# I/O and debugging
+parser.add_argument("-plot_pdf", help="Toggle plotting to .pdf")
+parser.add_argument("-plot_png", help="Toggle plotting to .png")
+parser.add_argument("-plot_pvd", help="Toggle plotting to .pvd")
+parser.add_argument("-plot_all", help="Toggle plotting to .pdf, .png and .pvd")
 parser.add_argument("-debug", help="Print all debugging statements")
+parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
+
 args, unknown = parser.parse_known_args()
 p = args.norm_order
 
-# Collect locations and radii
+
+# --- Set parameters
+
+plot_pdf = bool(args.plot_pdf or False)
+plot_png = bool(args.plot_png or False)
+plot_pvd = bool(args.plot_pvd or False)
+plot_all = bool(args.plot_all or False)
+if plot_all:
+    plot_pvd = plot_pdf = plot_png = True
+plot_any = plot_pdf or plot_png
+extensions = []
+if plot_pdf:
+    extensions.append('pdf')
+if plot_png:
+    extensions.append('png')
 if args.locations is None:
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-if args.radii is None:
-    radii = [100.0e+03 for l in locations]
-else:
-    radii = [float(r) for r in args.radii.split(',')]
-if len(locations) != len(radii):
-    msg = "Number of locations ({:d}) and radii ({:d}) do not match."
-    raise ValueError(msg.format(len(locations), len(radii)))
-
-# Set parameters for fixed mesh run
+radius = float(args.radius or 100.0e+03)
+family = args.family or 'cg-cg'  # FIXME: what's wrong with dg-cg?
+nonlinear = bool(args.nonlinear or False)
+stabilisation = args.stabilisation or 'lax_friedrichs'
+if stabilisation == 'none' or family == 'cg-cg' or not nonlinear:
+    stabilisation = None
 kwargs = {
+    'approach': 'dwp',
 
     # Space-time domain
-    'level': int(args.level or 2),
+    'level': int(args.level or 2),  # NOTE
     'end_time': float(args.end_time or 1440.0),
     'num_meshes': int(args.num_meshes or 12),
 
@@ -68,13 +92,12 @@ kwargs = {
     'bathymetry_cap': 30.0,  # FIXME
 
     # Solver
-    'family': args.family or 'cg-cg',
-    'stabilsation': None,  # TODO: Lax-Friedrichs
+    'family': family,
+    'stabilsation': stabilisation,
 
     # QoI
-    'start_time': float(args.start_time or 1200.0),
-    # 'start_time': float(args.start_time or 720.0),
-    'radii': radii,
+    'start_time': float(args.start_time or 0.0),
+    'radius': radius,
     'locations': locations,
 
     # Mesh adaptation
@@ -90,23 +113,27 @@ kwargs = {
     'num_adapt': int(args.num_adapt or 35),
 
     # Misc
+    'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
-    'plot_pvd': True,
+    'debug_mode': args.debug_mode or 'basic'
 }
 assert 0.0 <= kwargs['start_time'] <= kwargs['end_time']
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
 print_output(logstr + 80*'*' + '\n')
+op = TohokuOptions(**kwargs)
 
-# Create parameter class and problem object
-op = TohokuOptions(approach='dwp')
-op.update(kwargs)
-swp = AdaptiveTsunamiProblem(op)
+
+# --- Solve
+
+swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)
 swp.run_dwp()
 
-# Print summary / logging
-with open(os.path.join(os.path.dirname(__file__), '../../.git/logs/HEAD'), 'r') as gitlog:
+
+# --- Logging
+
+with open(os.path.join(os.path.dirname(__file__), '../../../.git/logs/HEAD'), 'r') as gitlog:
     for line in gitlog:
         words = line.split()
     logstr += "    {:34s}: {:}\n".format('adapt_utils git commit', words[1])
@@ -139,9 +166,10 @@ with open(os.path.join(di, 'log'), 'w') as logfile:
 print_output(di)
 
 # Plot element counts on a pie chart
-import matplotlib.pyplot as plt
-N = swp.num_cells[-1]
-plt.pie(N, labels=["Mesh {:d} ({:d})".format(i, n) for i, n in enumerate(N)])
-plt.title("Element counts for DWP adaptation")
-plt.savefig(os.path.join(di, 'pie.png'))
-plt.show()
+if plot_any:
+    N = swp.num_cells[-1]
+    plt.pie(N, labels=["Mesh {:d} ({:d})".format(i, n) for i, n in enumerate(N)])
+    plt.title("Element counts for DWP adaptation")
+    for ext in extensions:
+        plt.savefig(os.path.join(di, 'pie' + ext))
+    plt.show()

--- a/case_studies/tohoku/hazard/run_dwp.py
+++ b/case_studies/tohoku/hazard/run_dwp.py
@@ -84,7 +84,7 @@ kwargs = {
     'approach': 'dwp',
 
     # Space-time domain
-    'level': int(args.level or 2),  # NOTE
+    'level': int(args.level or 0),
     'end_time': float(args.end_time or 1440.0),
     'num_meshes': int(args.num_meshes or 12),
 

--- a/case_studies/tohoku/hazard/run_dwr.py
+++ b/case_studies/tohoku/hazard/run_dwr.py
@@ -2,10 +2,13 @@ from thetis import *
 
 import argparse
 import datetime
+import matplotlib.pyplot as plt
 
 from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
 from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
 
+
+# --- Parse arguments
 
 parser = argparse.ArgumentParser(prog="run_dwr")
 
@@ -16,6 +19,8 @@ parser.add_argument("-num_meshes", help="Number of meshes to consider (default 1
 
 # Solver
 parser.add_argument("-family", help="Element family for mixed FE space")
+parser.add_argument("-nonlinear", help="Toggle nonlinear equations (default False)")
+parser.add_argument("-stabilisation", help="Stabilisation method to use (default None)")
 
 # Mesh adaptation
 parser.add_argument("-norm_order", help="p for Lp normalisation (default 1)")
@@ -31,33 +36,51 @@ parser.add_argument("-qoi_rtol", help="Relative tolerance for quantity of intere
 
 # QoI
 parser.add_argument("-start_time", help="""
-Start time of period of interest (default 1200s i.e. 20mins)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
-Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
-'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
-""")
-parser.add_argument("-radii", help="Radii of interest, separated by commas (default 100km)")
+    Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
+    'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
+    """)
+parser.add_argument("-radius", help="Radius of interest (default 100km)")
 
-# Misc
+# I/O and debugging
+parser.add_argument("-plot_pdf", help="Toggle plotting to .pdf")
+parser.add_argument("-plot_png", help="Toggle plotting to .png")
+parser.add_argument("-plot_pvd", help="Toggle plotting to .pvd")
+parser.add_argument("-plot_all", help="Toggle plotting to .pdf, .png and .pvd")
 parser.add_argument("-debug", help="Print all debugging statements")
+parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
+
 args, unknown = parser.parse_known_args()
 p = args.norm_order
 
-# Collect locations and radii
+
+# --- Set parameters
+
+plot_pdf = bool(args.plot_pdf or False)
+plot_png = bool(args.plot_png or False)
+plot_pvd = bool(args.plot_pvd or False)
+plot_all = bool(args.plot_all or False)
+if plot_all:
+    plot_pvd = plot_pdf = plot_png = True
+plot_any = plot_pdf or plot_png
+extensions = []
+if plot_pdf:
+    extensions.append('pdf')
+if plot_png:
+    extensions.append('png')
 if args.locations is None:
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-if args.radii is None:
-    radii = [100.0e+03 for l in locations]
-else:
-    radii = [float(r) for r in args.radii.split(',')]
-if len(locations) != len(radii):
-    msg = "Number of locations ({:d}) and radii ({:d}) do not match."
-    raise ValueError(msg.format(len(locations), len(radii)))
-
-# Set parameters for fixed mesh run
+radius = float(args.radius or 100.0e+03)
+family = args.family or 'cg-cg'  # FIXME: what's wrong with dg-cg?
+nonlinear = bool(args.nonlinear or False)
+stabilisation = args.stabilisation or 'lax_friedrichs'
+if stabilisation == 'none' or family == 'cg-cg' or not nonlinear:
+    stabilisation = None
 kwargs = {
+    'approach': 'dwr',
     'estimate_error': True,
 
     # Space-time domain
@@ -73,9 +96,8 @@ kwargs = {
     'stabilsation': None,  # TODO: Lax-Friedrichs
 
     # QoI
-    'start_time': float(args.start_time or 1200.0),
-    # 'start_time': float(args.start_time or 720.0),
-    'radii': radii,
+    'start_time': float(args.start_time or 0.0),
+    'radius': radius,
     'locations': locations,
 
     # Mesh adaptation
@@ -99,15 +121,18 @@ logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
 print_output(logstr + 80*'*' + '\n')
+op = TohokuOptions(**kwargs)
 
-# Create parameter class and problem object
-op = TohokuOptions(approach='dwr')
-op.update(kwargs)
-swp = AdaptiveTsunamiProblem(op)
+
+# --- Solve
+
+swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)
 swp.run_dwr()
 
-# Print summary / logging
-with open(os.path.join(os.path.dirname(__file__), '../../.git/logs/HEAD'), 'r') as gitlog:
+
+# --- Logging
+
+with open(os.path.join(os.path.dirname(__file__), '../../../.git/logs/HEAD'), 'r') as gitlog:
     for line in gitlog:
         words = line.split()
     logstr += "    {:34s}: {:}\n".format('adapt_utils git commit', words[1])
@@ -140,9 +165,10 @@ with open(os.path.join(di, 'log'), 'w') as logfile:
 print_output(di)
 
 # Plot element counts on a pie chart
-import matplotlib.pyplot as plt
-N = swp.num_cells[-1]
-plt.pie(N, labels=["Mesh {:d} ({:d})".format(i, n) for i, n in enumerate(N)])
-plt.title("Element counts for DWR adaptation")
-plt.savefig(os.path.join(di, 'pie.png'))
-plt.show()
+if plot_any:
+    N = swp.num_cells[-1]
+    plt.pie(N, labels=["Mesh {:d} ({:d})".format(i, n) for i, n in enumerate(N)])
+    plt.title("Element counts for DWP adaptation")
+    for ext in extensions:
+        plt.savefig(os.path.join(di, 'pie' + ext))
+    plt.show()

--- a/case_studies/tohoku/hazard/run_dwr.py
+++ b/case_studies/tohoku/hazard/run_dwr.py
@@ -4,7 +4,7 @@ import argparse
 import datetime
 import matplotlib.pyplot as plt
 
-from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
+from adapt_utils.case_studies.tohoku.options.hazard_options import TohokuHazardOptions
 from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
 
 
@@ -124,7 +124,7 @@ for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
 logstr += "    {:34s}: {:}\n".format('nonlinear', nonlinear)
 print_output(logstr + 80*'*' + '\n')
-op = TohokuOptions(**kwargs)
+op = TohokuHazardOptions(**kwargs)
 
 
 # --- Solve

--- a/case_studies/tohoku/hazard/run_dwr.py
+++ b/case_studies/tohoku/hazard/run_dwr.py
@@ -84,7 +84,7 @@ kwargs = {
     'estimate_error': True,
 
     # Space-time domain
-    'level': int(args.level or 2),
+    'level': int(args.level or 0),
     'end_time': float(args.end_time or 1440.0),
     'num_meshes': int(args.num_meshes or 12),
 

--- a/case_studies/tohoku/hazard/run_dwr.py
+++ b/case_studies/tohoku/hazard/run_dwr.py
@@ -94,6 +94,7 @@ kwargs = {
     # Solver
     'family': args.family or 'cg-cg',
     'stabilsation': None,  # TODO: Lax-Friedrichs
+    'use_wetting_and_drying': False,
 
     # QoI
     'start_time': float(args.start_time or 0.0),
@@ -113,13 +114,15 @@ kwargs = {
     'num_adapt': int(args.num_adapt or 5),  # As recommended in [Belme et al. 2012]
 
     # Misc
-    'debug': bool(args.debug or False),
     'plot_pvd': True,
+    'debug': bool(args.debug or False),
+    'debug_mode': args.debug_mode or 'basic'
 }
 assert 0.0 <= kwargs['start_time'] <= kwargs['end_time']
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
+logstr += "    {:34s}: {:}\n".format('nonlinear', nonlinear)
 print_output(logstr + 80*'*' + '\n')
 op = TohokuOptions(**kwargs)
 

--- a/case_studies/tohoku/hazard/run_fixed_mesh.py
+++ b/case_studies/tohoku/hazard/run_fixed_mesh.py
@@ -83,11 +83,14 @@ op.update(kwargs)
 
 swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)
 if plot_pvd:
-    swp.get_qoi_kernels(0)
-    k_u, k_eta = swp.kernels[0].split()
-    kernel = Function(swp.P1[0], name="QoI kernel")
-    kernel.project(k_eta)
-    File(os.path.join(op.di, 'kernel.pvd')).write(kernel)
+    kernel_file = File(os.path.join(op.di, 'kernel.pvd'))
+    for i, P1 in enumerate(swp.P1):
+        swp.get_qoi_kernels(i)
+        k_u, k_eta = swp.kernels[i].split()
+        kernel = Function(P1, name="QoI kernel")
+        kernel.project(k_eta)
+        kernel_file._topology = None
+        kernel_file.write(kernel)
 swp.solve_forward()
 
 

--- a/case_studies/tohoku/hazard/run_fixed_mesh.py
+++ b/case_studies/tohoku/hazard/run_fixed_mesh.py
@@ -69,6 +69,11 @@ if args.locations is None:  # TODO: Parse as list
 else:
     locations = args.locations.split(',')
 radius = float(args.radius or 100.0e+03)
+family = args.family or 'cg-cg'
+nonlinear = bool(args.nonlinear or False)
+stabilisation = args.stabilisation or 'lax_friedrichs'
+if stabilisation == 'none' or family == 'cg-cg' or not nonlinear:
+    stabilisation = None
 kwargs = {
     'approach': 'fixed_mesh',
 
@@ -82,11 +87,11 @@ kwargs = {
     # 'bathymetry_cap': None,
 
     # Solver
-    'family': args.family or 'dg-cg',
-    'stabilsation': args.stabilisation,
+    'family': family,
+    'stabilsation': stabilisation,
     # 'use_wetting_and_drying': True,
     'use_wetting_and_drying': False,
-    'wetting_and_drying_alpha': Constant(10.0),
+    # 'wetting_and_drying_alpha': Constant(10.0),
 
     # QoI
     'start_time': float(args.start_time or 0.0),
@@ -98,7 +103,6 @@ kwargs = {
     'debug': bool(args.debug or False),
     'debug_mode': args.debug_mode or 'basic',
 }
-nonlinear = bool(args.nonlinear or False)
 op = TohokuHazardOptions(**kwargs)
 data_dir = create_directory(os.path.join(op.di, 'data'))
 plot_dir = create_directory(os.path.join(op.di, 'plots'))

--- a/case_studies/tohoku/hazard/run_fixed_mesh.py
+++ b/case_studies/tohoku/hazard/run_fixed_mesh.py
@@ -89,9 +89,7 @@ kwargs = {
     # Solver
     'family': family,
     'stabilsation': stabilisation,
-    # 'use_wetting_and_drying': True,
     'use_wetting_and_drying': False,
-    # 'wetting_and_drying_alpha': Constant(10.0),
 
     # QoI
     'start_time': float(args.start_time or 0.0),

--- a/case_studies/tohoku/hazard/run_fixed_mesh.py
+++ b/case_studies/tohoku/hazard/run_fixed_mesh.py
@@ -26,7 +26,7 @@ parser.add_argument("-stabilisation", help="Stabilisation method to use (default
 
 # QoI
 parser.add_argument("-start_time", help="""
-    Start time of period of interest in seconds (default 1440s i.e. 24min)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
     Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
     'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
@@ -47,9 +47,9 @@ args = parser.parse_args()
 
 # --- Set parameters
 
-plot_pvd = bool(args.plot_pvd or False)
 plot_pdf = bool(args.plot_pdf or False)
 plot_png = bool(args.plot_png or False)
+plot_pvd = bool(args.plot_pvd or False)
 plot_all = bool(args.plot_all or False)
 plot_only = bool(args.plot_only or False)
 if plot_only:
@@ -93,7 +93,7 @@ kwargs = {
     'radius': radius,
     'locations': locations,
 
-    # Misc
+    # I/O and debugging
     'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
     'debug_mode': args.debug_mode or 'basic',

--- a/case_studies/tohoku/hazard/run_hessian_based.py
+++ b/case_studies/tohoku/hazard/run_hessian_based.py
@@ -2,20 +2,25 @@ from thetis import *
 
 import argparse
 import datetime
+import os
 
 from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
 from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
 
 
+# --- Parse arguments
+
 parser = argparse.ArgumentParser(prog="run_hessian_based")
 
 # Space-time domain
-parser.add_argument("-end_time", help="End time of simulation (default 24 minutes)")
+parser.add_argument("-end_time", help="End time of simulation in seconds (default 1440s i.e. 24min)")
 parser.add_argument("-level", help="(Integer) mesh resolution (default 0)")
 parser.add_argument("-num_meshes", help="Number of meshes to consider (default 12)")
 
 # Solver
-parser.add_argument("-family", help="Element family for mixed FE space (default cg-cg)")
+parser.add_argument("-family", help="Element family for mixed FE space (default dg-cg)")
+parser.add_argument("-nonlinear", help="Toggle nonlinear equations (default False)")
+parser.add_argument("-stabilisation", help="Stabilisation method to use (default None)")
 
 # Mesh adaptation
 parser.add_argument("-norm_order", help="p for Lp normalisation (default 1)")
@@ -29,55 +34,58 @@ parser.add_argument("-h_max", help="Maximum tolerated element size (default 1000
 
 # QoI
 parser.add_argument("-start_time", help="""
-Start time of period of interest in seconds (default 1200s i.e. 20min)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
-Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
-'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
-""")
-parser.add_argument("-radii", help="Radii of interest, separated by commas (default 100km)")
+    Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
+    'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
+    """)
+parser.add_argument("-radius", help="Radius of interest (default 100km)")
 
 # Outer loop
 parser.add_argument("-num_adapt", help="Maximum number of adaptation loop iterations (default 35)")
 parser.add_argument("-element_rtol", help="Relative tolerance for element count (default 0.005)")
 parser.add_argument("-qoi_rtol", help="Relative tolerance for quantity of interest (default 0.005)")
 
-# Misc
+# I/O and debugging
 parser.add_argument("-save_plex", help="Save final set of mesh DMPlexes to disk")
+parser.add_argument("-plot_pvd", help="Toggle plotting to .pvd")
 parser.add_argument("-debug", help="Print all debugging statements")
+parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
+
 args, unknown = parser.parse_known_args()
 p = args.norm_order
 
-# Collect locations and radii
+
+# --- Set parameters
+
 if args.locations is None:
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-if args.radii is None:
-    radii = [100.0e+03 for l in locations]
-else:
-    radii = [float(r) for r in args.radii.split(',')]
-if len(locations) != len(radii):
-    msg = "Number of locations ({:d}) and radii ({:d}) do not match."
-    raise ValueError(msg.format(len(locations), len(radii)))
-
+radius = args.radius or 100.0e+03
+plot_pvd = bool(args.plot_pvd or False)
 kwargs = {
+    'approach': 'hessian',
 
     # Space-time domain
     'level': int(args.level or 0),
-    'end_time': float(args.end_time or 1440.0),
     'num_meshes': int(args.num_meshes or 12),
+    'end_time': float(args.end_time or 24*60.0),
 
     # Physics
     'bathymetry_cap': 30.0,  # FIXME
 
     # Solver
-    'family': args.family or 'cg-cg',
-    'stabilisation': None,  # TODO: Lax-Friedrichs
+    'family': args.family or 'dg-cg',
+    'stabilisation': args.stabilisation,
+    # 'use_wetting_and_drying': True,
+    'use_wetting_and_drying': False,
+    'wetting_and_drying_alpha': Constant(10.0),
 
     # Mesh adaptation
     'adapt_field': args.adapt_field or 'elevation',
     'hessian_time_combination': args.time_combine or 'integrate',
-    'hessian_timestep_lag': float(args.hessian_lag or 6),
+    'hessian_timestep_lag': float(args.hessian_lag or 1),
     'normalisation': args.normalisation or 'complexity',
     'norm_order': 1 if p is None else None if p == 'inf' else float(p),
     'target': float(args.target or 5.0e+03),
@@ -85,8 +93,8 @@ kwargs = {
     'h_max': float(args.h_max or 1.0e+06),
 
     # QoI
-    'start_time': float(args.start_time or 1200.0),
-    'radii': radii,
+    'start_time': float(args.start_time or 0.0),
+    'radius': radius,
     'locations': locations,
 
     # Outer loop
@@ -94,9 +102,10 @@ kwargs = {
     'qoi_rtol': float(args.qoi_rtol or 0.005),
     'num_adapt': int(args.num_adapt or 35),
 
-    # Misc
+    # I/O and debugging
+    'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
-    'plot_pvd': True,
+    'debug_mode': args.debug_mode or 'basic'
 }
 save_plex = bool(args.save_plex or False)
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
@@ -104,13 +113,16 @@ for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
 print_output(logstr + 80*'*' + '\n')
 
-# Create parameter class and problem object
-op = TohokuOptions(approach='hessian')
-op.update(kwargs)
+
+# --- Solve
+
+op = TohokuOptions(**kwargs)
 swp = AdaptiveTsunamiProblem(op)  # TODO: Option to load plexes
 swp.run_hessian_based()
 
-# Print summary / logging
+
+# --- Logging
+
 with open(os.path.join(os.path.dirname(__file__), '../../.git/logs/HEAD'), 'r') as gitlog:
     for line in gitlog:
         words = line.split()

--- a/case_studies/tohoku/hazard/run_hessian_based.py
+++ b/case_studies/tohoku/hazard/run_hessian_based.py
@@ -83,9 +83,7 @@ kwargs = {
     # Solver
     'family': family,
     'stabilisation': stabilisation,
-    # 'use_wetting_and_drying': True,
     'use_wetting_and_drying': False,
-    'wetting_and_drying_alpha': Constant(10.0),
 
     # Mesh adaptation
     'adapt_field': args.adapt_field or 'elevation',
@@ -116,6 +114,7 @@ save_plex = bool(args.save_plex or False)
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
+logstr += "    {:34s}: {:}\n".format('nonlinear', nonlinear)
 print_output(logstr + 80*'*' + '\n')
 
 

--- a/case_studies/tohoku/hazard/run_hessian_based.py
+++ b/case_studies/tohoku/hazard/run_hessian_based.py
@@ -4,7 +4,7 @@ import argparse
 import datetime
 import os
 
-from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
+from adapt_utils.case_studies.tohoku.options.hazard_options import TohokuHazardOptions
 from adapt_utils.unsteady.swe.tsunami.solver import AdaptiveTsunamiProblem
 
 
@@ -120,7 +120,7 @@ print_output(logstr + 80*'*' + '\n')
 
 # --- Solve
 
-op = TohokuOptions(**kwargs)
+op = TohokuHazardOptions(**kwargs)
 swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)  # TODO: Option to load plexes
 swp.run_hessian_based()
 

--- a/case_studies/tohoku/hazard/run_hessian_based.py
+++ b/case_studies/tohoku/hazard/run_hessian_based.py
@@ -47,7 +47,7 @@ parser.add_argument("-element_rtol", help="Relative tolerance for element count 
 parser.add_argument("-qoi_rtol", help="Relative tolerance for quantity of interest (default 0.005)")
 
 # I/O and debugging
-parser.add_argument("-save_plex", help="Save final set of mesh DMPlexes to disk")
+parser.add_argument("-save_meshes", help="Save final set of mesh DMPlexes to disk")
 parser.add_argument("-plot_pvd", help="Toggle plotting to .pvd")
 parser.add_argument("-debug", help="Print all debugging statements")
 parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
@@ -110,7 +110,7 @@ kwargs = {
     'debug': bool(args.debug or False),
     'debug_mode': args.debug_mode or 'basic'
 }
-save_plex = bool(args.save_plex or False)
+save_meshes = bool(args.save_meshes or False)
 logstr = 80*'*' + '\n' + 33*' ' + 'PARAMETERS\n' + 80*'*' + '\n'
 for key in kwargs:
     logstr += "    {:34s}: {:}\n".format(key, kwargs[key])
@@ -121,7 +121,7 @@ print_output(logstr + 80*'*' + '\n')
 # --- Solve
 
 op = TohokuHazardOptions(**kwargs)
-swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)  # TODO: Option to load plexes
+swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)  # TODO: Option to load meshes
 swp.run_hessian_based()
 
 
@@ -155,6 +155,6 @@ while True:
     j += 1
 with open(os.path.join(di, 'log'), 'w') as logfile:
     logfile.write(logstr)
-if save_plex:
-    swp.store_plexes(di=di)
+if save_meshes:
+    swp.store_meshes(fpath=di)
 print_output(di)

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -59,7 +59,7 @@ kwargs = {
     'use_wetting_and_drying': False,
 
     # QoI
-    'start_time': float(args.start_time or 15*60.0),
+    'start_time': float(args.start_time or 0.0),
     'radius': radius,
     'locations': locations,
 

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -19,6 +19,7 @@ parser.add_argument("-num_meshes", help="Number of meshes to consider (for testi
 # Solver
 parser.add_argument("-family", help="Element family for mixed FE space (default 'dg-cg')")
 parser.add_argument("-nonlinear", help="Toggle nonlinear equations (default False)")
+parser.add_argument("-stabilisation", help="Stabilisation method to use (default None)")
 
 # Outer loop
 parser.add_argument("-levels", help="Number of mesh levels to consider (default 5)")
@@ -34,13 +35,13 @@ parser.add_argument("-radius", help="Radius of interest (default 100km)")
 
 # I/O and debugging
 parser.add_argument("-debug", help="Print all debugging statements")
+parser.add_argument("-debug_mode", help="Choose debugging mode from 'basic' and 'full'")
 
 args = parser.parse_args()
 
 
 # --- Set parameters
 
-plot_pvd = bool(args.plot_pvd or False)
 if args.locations is None:  # TODO: Parse as list
     locations = ['Fukushima Daiichi', ]
 else:
@@ -52,6 +53,7 @@ stabilisation = args.stabilisation or 'lax_friedrichs'
 if stabilisation == 'none' or family == 'cg-cg' or not nonlinear:
     stabilisation = None
 kwargs = {
+    'approach': 'fixed_mesh',
 
     # Space-time domain
     'num_meshes': int(args.num_meshes or 1),
@@ -71,7 +73,6 @@ kwargs = {
     'locations': locations,
 
     # I/O and debugging
-    'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
 }
 levels = int(args.levels or 4)
@@ -86,8 +87,8 @@ for level in range(levels):
     print_output("Running qmesh convergence on level {:d}".format(level))
 
     # Set parameters
-    op = TohokuOptions(approach='fixed_mesh', level=level)
-    op.update(kwargs)
+    kwargs['level'] = level
+    op = TohokuOptions(**kwargs)
 
     # Solve
     swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -40,11 +40,17 @@ args = parser.parse_args()
 
 # --- Set parameters
 
+plot_pvd = bool(args.plot_pvd or False)
 if args.locations is None:  # TODO: Parse as list
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
-radius = args.radius or 100.0e+03
+radius = float(args.radius or 100.0e+03)
+family = args.family or 'cg-cg'
+nonlinear = bool(args.nonlinear or False)
+stabilisation = args.stabilisation or 'lax_friedrichs'
+if stabilisation == 'none' or family == 'cg-cg' or not nonlinear:
+    stabilisation = None
 kwargs = {
 
     # Space-time domain
@@ -55,7 +61,8 @@ kwargs = {
     'bathymetry_cap': 30.0,  # FIXME
 
     # Solver
-    'family': args.family or 'dg-cg',
+    'family': family,
+    'stabilisation': stabilisation,
     'use_wetting_and_drying': False,
 
     # QoI
@@ -64,11 +71,10 @@ kwargs = {
     'locations': locations,
 
     # I/O and debugging
-    'plot_pvd': True,
+    'plot_pvd': plot_pvd,
     'debug': bool(args.debug or False),
 }
 levels = int(args.levels or 4)
-nonlinear = bool(args.nonlinear or False)
 di = create_directory(os.path.join(os.path.dirname(__file__), 'outputs', 'qmesh'))
 
 
@@ -96,7 +102,7 @@ for level in range(levels):
 
 # --- Log results
 
-with open(os.path.join(os.path.dirname(__file__), '../../.git/logs/HEAD'), 'r') as gitlog:
+with open(os.path.join(os.path.dirname(__file__), '../../../.git/logs/HEAD'), 'r') as gitlog:
     for line in gitlog:
         words = line.split()
     kwargs['adapt_utils git commit'] = words[1]

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -40,7 +40,7 @@ args = parser.parse_args()
 
 # --- Set parameters
 
-if args.locations is None:
+if args.locations is None:  # TODO: Parse as list
     locations = ['Fukushima Daiichi', ]
 else:
     locations = args.locations.split(',')
@@ -67,7 +67,7 @@ kwargs = {
     'plot_pvd': True,
     'debug': bool(args.debug or False),
 }
-levels = int(args.levels or 5)
+levels = int(args.levels or 4)
 nonlinear = bool(args.nonlinear or False)
 di = create_directory(os.path.join(os.path.dirname(__file__), 'outputs', 'qmesh'))
 

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -25,7 +25,7 @@ parser.add_argument("-levels", help="Number of mesh levels to consider (default 
 
 # QoI
 parser.add_argument("-start_time", help="""
-    Start time of period of interest in seconds (default 1200s i.e. 20min)""")
+    Start time of period of interest in seconds (default zero)""")
 parser.add_argument("-locations", help="""
     Locations of interest, separated by commas. Choose from {'Fukushima Daiichi', 'Onagawa',
     'Fukushima Daini', 'Tokai', 'Hamaoka', 'Tohoku', 'Tokyo'}. (Default 'Fukushima Daiichi')
@@ -63,7 +63,7 @@ kwargs = {
     'radius': radius,
     'locations': locations,
 
-    # Misc
+    # I/O and debugging
     'plot_pvd': True,
     'debug': bool(args.debug or False),
 }

--- a/case_studies/tohoku/hazard/run_qmesh_convergence.py
+++ b/case_studies/tohoku/hazard/run_qmesh_convergence.py
@@ -78,14 +78,13 @@ qois = []
 num_cells = []
 for level in range(levels):
     print_output("Running qmesh convergence on level {:d}".format(level))
-    ext = "{:s}linear_level{:d}".format('non' if nonlinear else '', level)
 
     # Set parameters
     op = TohokuOptions(approach='fixed_mesh', level=level)
     op.update(kwargs)
 
     # Solve
-    swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear, extension=ext)
+    swp = AdaptiveTsunamiProblem(op, nonlinear=nonlinear)
     swp.solve_forward()
     qoi = swp.quantity_of_interest()
     print_output("Quantity of interest: {:.4e}".format(qoi))

--- a/case_studies/tohoku/inversion/1d/continuous.py
+++ b/case_studies/tohoku/inversion/1d/continuous.py
@@ -445,4 +445,3 @@ if plot_pdf:
         axes[i//N, i % N].axis(False)
     plt.tight_layout()
     plt.savefig(os.path.join(plot_dir, 'continuous', 'timeseries_optimised_{:d}.pdf'.format(level)))
-print_output("Done!")

--- a/case_studies/tohoku/inversion/1d/discrete.py
+++ b/case_studies/tohoku/inversion/1d/discrete.py
@@ -373,4 +373,3 @@ if plot_pdf:
         axes[i//N, i % N].axis(False)
     plt.tight_layout()
     plt.savefig(os.path.join(plot_dir, 'discrete', 'timeseries_optimised_{:d}.pdf'.format(level)))
-print_output("Done!")

--- a/case_studies/tohoku/inversion/1d/makefile
+++ b/case_studies/tohoku/inversion/1d/makefile
@@ -3,21 +3,15 @@ all: discrete continuous
 discrete:
 	@echo "Running discrete adjoint inversion on mesh 1/3..."
 	@python3 discrete.py -level 0 -recompute_parameter_space 1 -rerun_optimisation 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion on mesh 2/3..."
 	@python3 discrete.py -level 1 -recompute_parameter_space 1 -rerun_optimisation 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion on mesh 3/3..."
 	@python3 discrete.py -level 2 -recompute_parameter_space 1 -rerun_optimisation 1
-	@echo "Done!"
 
 continuous:
 	@echo "Running continuous adjoint inversion on mesh 1/3..."
 	@python3 continuous.py -level 0 -rerun_optimisation 1
-	@echo "Done!"
 	@echo "Running continuous adjoint inversion on mesh 2/3..."
 	@python3 continuous.py -level 1 -rerun_optimisation 1
-	@echo "Done!"
 	@echo "Running continuous adjoint inversion on mesh 3/3..."
 	@python3 continuous.py -level 2 -rerun_optimisation 1
-	@echo "Done!"

--- a/case_studies/tohoku/inversion/box/discrete.py
+++ b/case_studies/tohoku/inversion/box/discrete.py
@@ -375,4 +375,3 @@ if plot_pdf or plot_png:
         axes[i//N, i % N].axis(False)
     plt.tight_layout()
     savefig(os.path.join(plot_dir, 'discrete', 'timeseries_optimised_{:d}'.format(level)))
-print_output("Done!")

--- a/case_studies/tohoku/inversion/box/makefile
+++ b/case_studies/tohoku/inversion/box/makefile
@@ -3,15 +3,11 @@ all: project discrete
 project:
 	@echo "Testing projection for piecewise constant basis"
 	@python3 test_project.py -plot_all 1
-	@echo "Done!"
 
 discrete:
 	@echo "Running discrete adjoint inversion in  piecewise constant basis on mesh 1/3..."
 	@python3 discrete.py -level 0 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion in  piecewise constant basison mesh 2/3..."
 	@python3 discrete.py -level 1 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion in  piecewise constant basis on mesh 3/3..."
 	@python3 discrete.py -level 2 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"

--- a/case_studies/tohoku/inversion/box/test_project.py
+++ b/case_studies/tohoku/inversion/box/test_project.py
@@ -138,7 +138,6 @@ for level in range(levels):
             print_output("Solving forward on {:s}...".format(swp.__class__.__name__))
             swp.setup_solver_forward(0)
             swp.solve_forward_step(0)
-            print_output("Done!")
         for gauge in gauges:
             for options, name in zip((op_saito, op), ('original', 'projected')):
                 for tt in ('timeseries', 'timeseries_smooth'):

--- a/case_studies/tohoku/inversion/radial/discrete.py
+++ b/case_studies/tohoku/inversion/radial/discrete.py
@@ -377,4 +377,3 @@ if plot_pdf or plot_png:
         axes[i//N, i % N].axis(False)
     plt.tight_layout()
     savefig(os.path.join(plot_dir, 'discrete', 'timeseries_optimised_{:d}'.format(level)))
-print_output("Done!")

--- a/case_studies/tohoku/inversion/radial/makefile
+++ b/case_studies/tohoku/inversion/radial/makefile
@@ -3,15 +3,11 @@ all: project discrete
 project:
 	@echo "Testing projection for radial basis"
 	@python3 test_project.py -plot_all 1
-	@echo "Done!"
 
 discrete:
 	@echo "Running discrete adjoint inversion in radial basis on mesh 1/3..."
 	@python3 discrete.py -level 0 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion in radial basis on mesh 2/3..."
 	@python3 discrete.py -level 1 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"
 	@echo "Running discrete adjoint inversion in radial basis on mesh 3/3..."
 	@python3 discrete.py -level 2 -rerun_optimisation 1 -plot_all 1
-	@echo "Done!"

--- a/case_studies/tohoku/inversion/radial/test_project.py
+++ b/case_studies/tohoku/inversion/radial/test_project.py
@@ -138,7 +138,6 @@ for level in range(levels):
             print_output("Solving forward on {:s}...".format(swp.__class__.__name__))
             swp.setup_solver_forward(0)
             swp.solve_forward_step(0)
-            print_output("Done!")
         for gauge in gauges:
             for options, name in zip((op_saito, op), ('original', 'projected')):
                 for tt in ('timeseries', 'timeseries_smooth'):

--- a/case_studies/tohoku/makefile
+++ b/case_studies/tohoku/makefile
@@ -4,7 +4,6 @@ all: dir mesh gauges clean
 dir:
 	@echo "Creating output directory..."
 	@mkdir -p outputs
-	@echo "Done!"
 
 
 # --- Meshes
@@ -13,14 +12,12 @@ mesh:
 	@echo "Generating meshes..."
 	@mkdir -p resources/meshes
 	@python meshgen.py
-	@echo "Done!"
 
 mesh_postproc:
 	@echo "Post-processing meshes..."
 	@python3 resources/meshes/postproc.py \
 		-dm_plex_prescribed_boundary_labels 100,200,300 \
 		-dm_plex_prescribed_boundary_sizes 100e3,10e3,5e3 -dm_plex_remesh_bd
-	@echo "Done!"
 
 
 # --- Gauges
@@ -28,32 +25,26 @@ mesh_postproc:
 manual_download_gauges:
 	@echo "Checking gauge data which require manual downloads exist..."
 	@python3 resources/gauges/check_manual_downloads.py
-	@echo "Done!"
 
 download_gauges:
 	@echo "Downloading gauge data..."
 	@cd resources/gauges/ && ./extract_gps_gauge_data.sh
-	@echo "Done!"
 
 extract_gauges:
 	@echo "Extracting gauge data..."
 	@cd resources/gauges/ && ./extract_kpg.sh && ./extract_mpg.sh
-	@echo "Done!"
 
 preproc_gauges:
 	@echo "Pre-processing gauge data..."
 	@python3 resources/gauges/preproc.py all
-	@echo "Done!"
 
 plot_gauges:
 	@echo "Plotting gauge data..."
 	@python3 plot_gauge_data.py
-	@echo "Done!"
 
 clean_gauges:
 	@echo "Cleaning gauge data directory..."
 	@cd resources/gauges && rm -rf outputs/ && rm -rf __pycache__/ && rm *_mmh.*
-	@echo "Done!"
 
 gauges: download_gauges extract_gauges preproc_gauges plot_gauges clean_gauges
 

--- a/case_studies/tohoku/options/box_options.py
+++ b/case_studies/tohoku/options/box_options.py
@@ -54,7 +54,6 @@ class TohokuBoxBasisOptions(TohokuOptions):
             control = thetis.Function(R, name="Control parameter {:d}".format(i))
             control.assign(control_parameters[i])
             self.control_parameters.append(control)
-        self.print_debug("INIT: Done!")
         self.strike_angle = kwargs.get('strike_angle', 7*np.pi/12)
 
     def get_basis_functions(self, fs):
@@ -83,7 +82,6 @@ class TohokuBoxBasisOptions(TohokuOptions):
                 x_rot, y_rot = tuple(np.array([x0, y0]) + np.dot(R, np.array([x, y])))
                 self._array.append([x_rot, y_rot])
                 phi.interpolate(box([(x_rot, y_rot, rx, ry), ], fs.mesh(), rotation=angle))
-        self.print_debug("INIT: Done!")
 
     def set_initial_condition(self, prob, sum_pad=100):
         """
@@ -102,7 +100,6 @@ class TohokuBoxBasisOptions(TohokuOptions):
         for n in range(0, self.nx*self.ny, sum_pad):
             expr = sum(m*g for m, g in zip(controls[n:n+sum_pad], self.basis_functions[n:n+sum_pad]))
             prob.fwd_solutions[0].assign(prob.fwd_solutions[0] + thetis.project(expr, prob.V[0]))
-        self.print_debug("INIT: Done!")
 
         # Subtract initial surface from the bathymetry field
         self.subtract_surface_from_bathymetry(prob)

--- a/case_studies/tohoku/options/hazard_options.py
+++ b/case_studies/tohoku/options/hazard_options.py
@@ -1,6 +1,9 @@
-import thetis
+from thetis import PointNotInDomainError
+
 import numpy as np
+
 from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
+from adapt_utils.unsteady.swe.tsunami.conversion import from_latlon
 
 
 __all__ = ["TohokuHazardOptions"]
@@ -89,14 +92,14 @@ class TohokuHazardOptions(TohokuOptions):
 
     def _get_update_forcings_forward(self, prob, i):
 
-        def update_forcings():
+        def update_forcings(t):
             return
 
         return update_forcings
 
     def _get_update_forcings_adjoint(self, prob, i):
 
-        def update_forcings():
+        def update_forcings(t):
             return
 
         return update_forcings

--- a/case_studies/tohoku/options/hazard_options.py
+++ b/case_studies/tohoku/options/hazard_options.py
@@ -22,7 +22,7 @@ class TohokuHazardOptions(TohokuOptions):
         #     2 hour simulation period.
         #   * In this class we are only interested in the tsunami's approach of the coast and
         #     therefore use a reduced time window.
-        self.start_time = kwargs.get('start_time', 15*60.0)
+        self.start_time = kwargs.get('start_time', 0.0)
         self.end_time = kwargs.get('end_time', 24*60.0)
         # self.end_time = kwargs.get('end_time', 60*60.0)
 

--- a/case_studies/tohoku/options/hazard_options.py
+++ b/case_studies/tohoku/options/hazard_options.py
@@ -1,0 +1,135 @@
+import thetis
+import numpy as np
+from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
+
+
+__all__ = ["TohokuHazardOptions"]
+
+
+class TohokuHazardOptions(TohokuOptions):
+    # TODO: doc
+    def __init__(self, *args, **kwargs):
+        """
+        :kwarg radius: distance indicating radii around the locations of interest, thereby
+            determining regions of interest for use in hazard assessment QoIs.
+        """
+        super(TohokuHazardOptions, self).__init__(*args, **kwargs)
+
+        # Timestepping
+        # ============
+        #   * The parent class is geared up for gauge timeseries inversion and therefore uses a
+        #     2 hour simulation period.
+        #   * In this class we are only interested in the tsunami's approach of the coast and
+        #     therefore use a reduced time window.
+        self.start_time = kwargs.get('start_time', 15*60.0)
+        self.end_time = kwargs.get('end_time', 24*60.0)
+        # self.end_time = kwargs.get('end_time', 60*60.0)
+
+        # Location classifications
+        self.locations_to_consider = (
+            # "Onagawa",
+            # "Tokai",
+            # "Hamaoka",
+            # "Tohoku",
+            # "Tokyo",
+            "Fukushima Daiichi",
+            # "Fukushima Daini",
+        )
+        self.get_locations_of_interest(**kwargs)
+
+    def get_locations_of_interest(self, **kwargs):
+        """
+        Read in locations of interest, determine their coordinates and check these coordinate lie
+        within the domain.
+
+        The possible coastal locations of interest include major cities and nuclear power plants:
+
+        * Cities:
+          - Onagawa;
+          - Tokai;
+          - Hamaoka;
+          - Tohoku;
+          - Tokyo.
+
+        * Nuclear power plants:
+          - Fukushima Daiichi;
+          - Fukushima Daini.
+        """
+        radius = kwargs.get('radius', 50.0e+03)
+        locations_of_interest = {
+            "Onagawa": {"lonlat": (141.5008, 38.3995)},
+            "Tokai": {"lonlat": (140.6067, 36.4664)},
+            "Hamaoka": {"lonlat": (138.1433, 34.6229)},
+            "Tohoku": {"lonlat": (141.3903, 41.1800)},
+            "Tokyo": {"lonlat": (139.6917, 35.6895)},
+            "Fukushima Daiichi": {"lonlat": (141.0281, 37.4213)},
+            "Fukushima Daini": {"lonlat": (141.0249, 37.3166)},
+        }
+
+        # Convert coordinates to UTM and create timeseries array
+        self.locations_of_interest = {}
+        for loc in self.locations_to_consider:
+            self.locations_of_interest[loc] = {"data": [], "timeseries": []}
+            self.locations_of_interest[loc]["lonlat"] = locations_of_interest[loc]["lonlat"]
+            lon, lat = self.locations_of_interest[loc]["lonlat"]
+            self.locations_of_interest[loc]["utm"] = from_latlon(lat, lon, force_zone_number=54)
+            self.locations_of_interest[loc]["coords"] = self.locations_of_interest[loc]["utm"]
+
+        # Check validity of gauge coordinates
+        for loc in self.locations_to_consider:
+            try:
+                self.default_mesh.coordinates.at(self.locations_of_interest[loc]['coords'])
+            except PointNotInDomainError:
+                self.print_debug("NOTE: Location {:s} is not in the domain; removing it".format(loc))
+                self.locations_of_interest.pop(loc)
+
+        # Regions of interest
+        loi = self.locations_of_interest
+        self.region_of_interest = [loi[loc]["coords"] + (radius, ) for loc in loi]
+
+    def _get_update_forcings_forward(self, prob, i):
+
+        def update_forcings():
+            return
+
+        return update_forcings
+
+    def _get_update_forcings_adjoint(self, prob, i):
+
+        def update_forcings():
+            return
+
+        return update_forcings
+
+    def get_regularisation_term(self, prob):
+        raise NotImplementedError
+
+    def annotate_plot(self, axes, coords="utm", fontsize=12):
+        """
+        Annotate `axes` in coordinate system `coords` with all locations of interest.
+
+        :arg axes: `matplotlib.pyplot` :class:`axes` object.
+        :kwarg coords: coordinate system, from 'lonlat' and 'utm'.
+        :kwarg fontsize: font size to use in annotations.
+        """
+        if coords not in ("lonlat", "utm"):
+            raise ValueError("Coordinate system {:s} not recognised.".format(coords))
+        dat = self.gauges if gauges else self.locations_of_interest
+        offset = 40.0e+03
+        for loc in dat:
+            x, y = np.copy(dat[loc][coords])
+            kwargs = {
+                "xy": dat[loc][coords],
+                "color": "indigo",
+                "ha": "right",
+                "va": "center",
+                "fontsize": fontsize,
+            }
+            if loc == "Fukushima Daini":
+                continue
+            elif loc == "Fukushima Daiichi":
+                loc = "Fukushima"
+            x += offset
+            kwargs["xytext"] = (x, y)
+            axes.plot(*dat[loc][coords], 'x', color=kwargs["color"])
+            axes.annotate(loc, **kwargs)

--- a/case_studies/tohoku/options/hazard_options.py
+++ b/case_studies/tohoku/options/hazard_options.py
@@ -1,5 +1,3 @@
-from thetis import PointNotInDomainError
-
 import numpy as np
 
 from adapt_utils.case_studies.tohoku.options.options import TohokuOptions
@@ -77,14 +75,6 @@ class TohokuHazardOptions(TohokuOptions):
             lon, lat = self.locations_of_interest[loc]["lonlat"]
             self.locations_of_interest[loc]["utm"] = from_latlon(lat, lon, force_zone_number=54)
             self.locations_of_interest[loc]["coords"] = self.locations_of_interest[loc]["utm"]
-
-        # Check validity of gauge coordinates
-        for loc in self.locations_to_consider:
-            try:
-                self.default_mesh.coordinates.at(self.locations_of_interest[loc]['coords'])
-            except PointNotInDomainError:
-                self.print_debug("NOTE: Location {:s} is not in the domain; removing it".format(loc))
-                self.locations_of_interest.pop(loc)
 
         # Regions of interest
         loi = self.locations_of_interest

--- a/case_studies/tohoku/options/okada_options.py
+++ b/case_studies/tohoku/options/okada_options.py
@@ -271,7 +271,6 @@ class TohokuOkadaBasisOptions(TohokuOptions):
         # Create the topography, thereby calling Okada
         self.print_debug("SETUP: Creating topography using Okada model...")
         self.fault.create_dtopography(verbose=self.debug, active=True)
-        self.print_debug("SETUP: Done!")
 
         # Mark output as dependent
         if separate_faults:
@@ -307,7 +306,6 @@ class TohokuOkadaBasisOptions(TohokuOptions):
         # Create the topography, thereby calling Okada
         self.print_debug("SETUP: Creating topography using Okada model...")
         self.fault.create_dtopography(verbose=self.debug, active=True)
-        self.print_debug("SETUP: Done!")
 
         # Compute quantity of interest
         self.J_subfaults = [0.0 for j in range(self.N)]
@@ -381,14 +379,12 @@ class TohokuOkadaBasisOptions(TohokuOptions):
         for i, coord in enumerate(self.okada_mesh.coordinates.dat.data):
             self._x_locations.append(int(np.round((coord[0] - self.xmin)*(self.N-1)/self.lx)))
             self._y_locations.append(int(np.round((coord[1] - self.ymin)*(self.N-1)/self.ly)))
-        self.print_debug("SETUP: Done!")
 
         # Create source and target images and a libsupermesh projector between them
         self.print_debug("SETUP: Establishing supermesh projector between Okada and lonlat meshes...")
         self.source_okada = firedrake.Function(self.P1_okada, name="Interp. source on Okada mesh")
         self.target_lonlat = firedrake.Function(self.P1_lonlat, name="Interp. target on lonlat mesh")
         self._okada2lonlat = SupermeshProjector(self.source_okada, self.target_lonlat)
-        self.print_debug("SETUP: Done!")
 
         # Target image on UTM mesh
         P1 = firedrake.FunctionSpace(self.default_mesh, "CG", 1)

--- a/case_studies/tohoku/options/options.py
+++ b/case_studies/tohoku/options/options.py
@@ -682,3 +682,11 @@ class TohokuOptions(TsunamiOptions):
         # diff = detided - elev
 
         return time, detided, elev
+
+    def set_qoi_kernel(self, prob, i):  # TODO: Use this instead of update_forcings
+        prob.kernels[i] = Function(prob.V[i], name="QoI kernel")
+        kernel_u, kernel_eta = prob.kernels[i].split()
+        kernel_u.rename("QoI kernel (velocity component)")
+        kernel_eta.rename("QoI kernel (elevation component)")
+        kernel_u.assign(0.0)
+        kernel_eta.assign(0.0)

--- a/case_studies/tohoku/options/options.py
+++ b/case_studies/tohoku/options/options.py
@@ -111,7 +111,7 @@ class TohokuOptions(TsunamiOptions):
         #  * There is a trade-off between having an unneccesarily small timestep and being able to
         #    represent the gauge timeseries profiles.
         self.timestepper = 'CrankNicolson'
-        self.dt = kwargs.get('dt', 60.0*0.5**level)
+        self.dt = kwargs.get('dt', 60.0*0.5**self.level)
         self.dt_per_export = int(60.0/self.dt)
         self.start_time = kwargs.get('start_time', 0.0)
         self.end_time = kwargs.get('end_time', 120*60.0)

--- a/case_studies/tohoku/options/options.py
+++ b/case_studies/tohoku/options/options.py
@@ -117,19 +117,6 @@ class TohokuOptions(TsunamiOptions):
         self.num_timesteps = int(self.end_time/self.dt + 1)
         self.times = [i*self.dt for i in range(self.num_timesteps)]
 
-        # Compute CFL number
-        if self.debug:
-            self.print_debug("INIT: Computing CFL number...")
-            P0 = FunctionSpace(self.default_mesh, "DG", 0)
-            P1 = FunctionSpace(self.default_mesh, "CG", 1)
-            b = self.set_bathymetry(P1).vector().gather().max()
-            g = self.g.values()[0]
-            celerity = np.sqrt(g*b)
-            dx = interpolate(CellDiameter(self.default_mesh), P0).vector().gather().max()
-            cfl = celerity*self.dt/dx
-            msg = "INIT:   dx = {:.4e}  dt = {:.4e}  CFL number = {:.4e} {:1s} 1"
-            self.print_debug(msg.format(dx, self.dt, cfl, '<' if cfl < 1 else '>'))
-
         # Gauge classifications
         self.near_field_pressure_gauges = {
             "gauges": ("P02", "P06"),

--- a/case_studies/tohoku/options/options.py
+++ b/case_studies/tohoku/options/options.py
@@ -96,7 +96,8 @@ class TohokuOptions(TsunamiOptions):
             self.default_mesh = mesh
 
         # Physics
-        self.friction = 'manning'
+        self.friction = None
+        # self.friction = 'manning'  # FIXME
         self.friction_coeff = 0.025
         self.base_viscosity = kwargs.get('base_viscosity', 0.0)
 

--- a/case_studies/tohoku/options/options.py
+++ b/case_studies/tohoku/options/options.py
@@ -94,7 +94,6 @@ class TohokuOptions(TsunamiOptions):
                 self.default_mesh = Mesh(os.path.join(self.mesh_dir, self.mesh_file) + '.msh')
         else:
             self.default_mesh = mesh
-        self.print_debug("INIT: Done!")
 
         # Physics
         self.friction = 'manning'
@@ -130,7 +129,6 @@ class TohokuOptions(TsunamiOptions):
             cfl = celerity*self.dt/dx
             msg = "INIT:   dx = {:.4e}  dt = {:.4e}  CFL number = {:.4e} {:1s} 1"
             self.print_debug(msg.format(dx, self.dt, cfl, '<' if cfl < 1 else '>'))
-            self.print_debug("INIT: Done!")
 
         # Gauge classifications
         self.near_field_pressure_gauges = {
@@ -192,7 +190,6 @@ class TohokuOptions(TsunamiOptions):
         else:
             raise ValueError("Bathymetry data source {:s} not recognised.".format(source))
         nc.close()
-        self.print_debug("INIT: Done!")
         return lon, lat, elev
 
     def read_surface_file(self, zeroed=True):
@@ -205,7 +202,6 @@ class TohokuOptions(TsunamiOptions):
         lat = nc.variables['lat' if zeroed else 'y'][:]
         elev = nc.variables['z'][:, :]
         nc.close()
-        self.print_debug("INIT: Done!")
         return lon, lat, elev
 
     def get_gauges(self):
@@ -367,7 +363,6 @@ class TohokuOptions(TsunamiOptions):
             except PointNotInDomainError:
                 self.print_debug("NOTE: Gauge {:5s} is not in the domain; removing it".format(gauge))
                 self.gauges.pop(gauge)
-        self.print_debug("INIT: Done!")
 
     def _get_update_forcings_forward(self, prob, i):  # TODO: Use QoICallback
         from adapt_utils.misc import ellipse
@@ -693,7 +688,6 @@ class TohokuOptions(TsunamiOptions):
         self.print_debug("INIT: Applying UTide de-tiding algorithm to gauge {:s}...".format(gauge))
         sol = utide.solve(time_str, anomaly, **kwargs)
         tide = utide.reconstruct(time_str, sol, verbose=self.debug)
-        self.print_debug("INIT: Done!")
 
         # Subtract de-tided component
         detided = anomaly - np.array(tide.h).reshape(anomaly.shape)

--- a/case_studies/tohoku/options/radial_options.py
+++ b/case_studies/tohoku/options/radial_options.py
@@ -67,7 +67,6 @@ class TohokuRadialBasisOptions(TohokuOptions):
             control = thetis.Function(R, name="Control parameter {:d}".format(i))
             control.assign(control_parameters[i])
             self.control_parameters.append(control)
-        self.print_debug("INIT: Done!")
         self.strike_angle = kwargs.get('strike_angle', 7*np.pi/12)
 
     def get_basis_functions(self, fs):  # TODO: Implement radial basis functions other than Gaussians
@@ -99,7 +98,6 @@ class TohokuRadialBasisOptions(TohokuOptions):
                 x_rot, y_rot = tuple(np.array([x0, y0]) + np.dot(R, np.array([x, y])))
                 self._array.append([x_rot, y_rot])
                 phi.interpolate(gaussian([(x_rot, y_rot, rx, ry), ], fs.mesh(), rotation=angle))
-        self.print_debug("INIT: Done!")
 
     def set_initial_condition(self, prob, sum_pad=100):
         """
@@ -118,7 +116,6 @@ class TohokuRadialBasisOptions(TohokuOptions):
         for n in range(0, self.nx*self.ny, sum_pad):
             expr = sum(m*g for m, g in zip(controls[n:n+sum_pad], self.basis_functions[n:n+sum_pad]))
             prob.fwd_solutions[0].assign(prob.fwd_solutions[0] + thetis.project(expr, prob.V[0]))
-        self.print_debug("INIT: Done!")
 
         # Subtract initial surface from the bathymetry field
         self.subtract_surface_from_bathymetry(prob)
@@ -158,23 +155,19 @@ class TohokuRadialBasisOptions(TohokuOptions):
         for i in range(N):
             for j in range(i+1, N):
                 A[i, j] = A[j, i]
-        self.print_debug("INTERPOLATION: Done!")
 
         # Assemble RHS
         self.print_debug("INTERPOLATION: Assembling RHS...")
         b = np.array([assemble(phi[i]*source*dx) for i in range(N)])
-        self.print_debug("INTERPOLATION: Done!")
 
         # Create solution vector and solve
         self.print_debug("INTERPOLATION: Solving linear system...")
         m = np.linalg.solve(A, b)
-        self.print_debug("INTERPOLATION: Done!")
 
         # Assign values
         self.print_debug("INTERPOLATION: Assigning values...")
         for i, mi in enumerate(m):
             self.control_parameters[i].assign(mi)
-        self.print_debug("INTERPOLATION: Done!")
 
     def interpolate(self, prob, source):
         r"""
@@ -235,10 +228,8 @@ class TohokuRadialBasisOptions(TohokuOptions):
             'fprime': dJdm,
         }
         m_opt = scipy.optimize.fmin_bfgs(J, m_init, **opt_kwargs)
-        self.print_debug("INTERPOLATION: Done!")
 
         # Assign values
         self.print_debug("INTERPOLATION: Assigning values...")
         for i, mi in enumerate(m_opt):
             self.control_parameters[i].assign(mi)
-        self.print_debug("INTERPOLATION: Done!")

--- a/case_studies/tohoku/resources/gauges/preproc.py
+++ b/case_studies/tohoku/resources/gauges/preproc.py
@@ -43,7 +43,6 @@ for gauge in gauges:
             gauge_lon, gauge_lat = op.gauges[gauge]["lonlat"]
             lon, lat, b = op.read_bathymetry_file()
             b = float(-si.RectBivariateSpline(lat, lon, b)(gauge_lat, gauge_lon))
-    op.print_debug("GAUGES: Done!")
 
     # I/O
     fname = os.path.join(os.path.dirname(__file__), '.'.join([gauge, 'txt']))

--- a/case_studies/tohoku/resources/meshes/postproc.py
+++ b/case_studies/tohoku/resources/meshes/postproc.py
@@ -22,7 +22,7 @@ for level in range(4):
 
     newmesh = adapt(mesh, M)
     viewer = PETSc.Viewer().createHDF5(fname + '.h5', 'w')
-    viewer(newmesh._plex)
+    viewer(newmesh._topology_dm)
 
     print("\n" + 40*"=" + "\n           before     after\n" + 40*"=")
     print("#elements: {:8d}     {:8d}".format(mesh.num_cells(), newmesh.num_cells()))

--- a/io.py
+++ b/io.py
@@ -31,7 +31,7 @@ def load_mesh(fname, fpath):
     if COMM_WORLD.size > 1:
         raise IOError("Loading a mesh from HDF5 only works in serial.")
     newplex = PETSc.DMPlex().create()
-    newplex.createFromFile(os.path.join(fpath, fname))
+    newplex.createFromFile(os.path.join(fpath, fname + '.h5'))
     return Mesh(newplex)
 
 

--- a/misc.py
+++ b/misc.py
@@ -13,7 +13,7 @@ __all__ = ["taylor_test", "StagnationError", "prod", "combine", "rotation_matrix
            "box", "ellipse", "bump", "circular_bump", "gaussian", "cg2dg", "copy_mesh",
            "get_finite_element", "get_component_space", "get_component", "get_boundary_nodes",
            "is_symmetric", "is_pos_def", "is_spd", "check_spd", "readfile", "num_days",
-           "find", "suppress_output", "knownargs2dict", "unknownargs2dict", "index_string"]
+           "find", "knownargs2dict", "unknownargs2dict", "index_string"]
 
 
 # --- Optimisation
@@ -490,27 +490,3 @@ def unknownargs2dict(ua):
         else:
             out[key] = val
     return out
-
-
-class suppress_output(object):
-    """Class used to suppress standard output or another stream."""
-    def __init__(self, stream=None):
-        self.origstream = stream or sys.stdout
-        self.origstreamfd = self.origstream.fileno()
-        self.pipe_out, self.pipe_in = os.pipe()  # Create a pipe to capture stream
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.stop()
-
-    def start(self):
-        """Start diverting stream data to pipe."""
-        os.dup2(self.pipe_in, self.origstreamfd)
-
-    def stop(self):
-        """Stop fiverting stream data to pipe."""
-        os.close(self.pipe_in)
-        os.close(self.pipe_out)

--- a/misc.py
+++ b/misc.py
@@ -414,7 +414,6 @@ def check_spd(M):
     except AssertionError:
         raise ValueError("FAIL: Matrix is not positive-definite")
     print_output("PASS: Matrix is indeed positive-definite")
-    print_output("TEST: Done!")
 
 
 # --- I/O

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+pytest
+vtk==9.0.1

--- a/steady/test_cases/point_discharge2d/makefile
+++ b/steady/test_cases/point_discharge2d/makefile
@@ -13,14 +13,11 @@ dir:
 	@mkdir -p outputs/loseille_averaged/hdf5
 	@mkdir -p outputs/loseille_superposed/hdf5
 	@mkdir -p data
-	@echo "Done!"
 
 uniform:
 	@echo "Running uniform convergence test..."
 	@python3 run_uniform_convergence.py
-	@echo "Done!"
 
 table:
 	@echo "Writing to LaTeX formatted table..."
 	@python3 write_table.py
-	@echo "Done!"

--- a/steady/test_cases/turbine_array/makefile
+++ b/steady/test_cases/turbine_array/makefile
@@ -18,12 +18,10 @@ dir:
 	@mkdir -p outputs/carpio_isotropic/hdf5
 	@mkdir -p outputs/carpio/hdf5
 	@mkdir -p data
-	@echo "Done!"
 
 geo:
 	@echo "Generating geometry files..."
 	@python3 generate_geo.py
-	@echo "Done!"
 
 mesh:
 	@echo "Generating all meshes..."
@@ -42,70 +40,57 @@ mesh:
 	@gmsh -2 medium_2.geo
 	@gmsh -2 fine_2.geo
 	@gmsh -2 xfine_2.geo
-	@echo "Done!"
 
 geo_xcoarse:
 	@echo "Generating xcoarse geometry files..."
 	@python3 generate_geo.py -level xcoarse
-	@echo "Done!"
 
 mesh_xcoarse:
 	@echo "Generating xcoarse meshes..."
 	@gmsh -2 xcoarse_0.geo
 	@gmsh -2 xcoarse_1.geo
 	@gmsh -2 xcoarse_2.geo
-	@echo "Done!"
 
 uniform:
 	@echo "Running uniform convergence test..."
 	@python3 run_uniform_convergence.py -offset 0
 	@python3 run_uniform_convergence.py -offset 1
-	@echo "Done!"
 
 isotropic:
 	@echo "Running isotropic adaptive convergence test..."
 	@python3 run_adaptive_convergence.py -approach carpio_isotropic
-	@echo "Done!"
 
 anisotropic:
 	@echo "Running anisotropic adaptive convergence test..."
 	@python3 run_adaptive_convergence.py -approach carpio
-	@echo "Done!"
 
 screenshot_uniform:
 	@echo "Individual run for uniform refinement screenshots..."
 	@python3 run.py -approach fixed_mesh -offset 0 -level 3
 	@python3 run.py -approach fixed_mesh -offset 1 -level 3
-	@echo "Done!"
 
 screenshot_isotropic:
 	@echo "Individual run for isotropic adaptation screenshots..."
 	@python3 run.py -approach carpio_isotropic -offset 0
 	@python3 run.py -approach carpio_isotropic -offset 1
-	@echo "Done!"
 
 screenshot_anisotropic:
 	@echo "Individual run for anisotropic adaptation screenshots..."
 	@python3 run.py -approach carpio -offset 0
 	@python3 run.py -approach carpio -offset 1
-	@echo "Done!"
 
 semilog:
 	@echo "Plotting convergence curves..."
 	@python3 plot_convergence.py
-	@echo "Done!"
 
 loglog:
 	@echo "Plotting convergence curves..."
 	@python3 plot_convergence.py -loglog 1
-	@echo "Done!"
 
 table:
 	@echo "Writing to LaTeX formatted table..."
 	@python3 write_table.py
-	@echo "Done!"
 
 clean:
 	@echo "Cleaning directory..."
 	@rm -Rf *.geo *.msh
-	@echo "Done!"

--- a/steady/test_cases/turbine_array/run.py
+++ b/steady/test_cases/turbine_array/run.py
@@ -24,10 +24,10 @@ parser.add_argument('-offset', help="""
     'Aligned' configuration given by offset=0, 'Offset' configuration given by offset=1.
     (Default 0)""")
 parser.add_argument('-debug', help="Toggle debugging mode (default False)")
-parser.add_argument('-save_plex', help="Save DMPlex to HDF5 (default False)")
+parser.add_argument('-save_mesh', help="Save DMPlex to HDF5 (default False)")
 parser.add_argument('-save_plot', help="Save plots of mesh and initial fluid speed (default False)")
 args = parser.parse_args()
-save_plex = bool(args.save_plex or False)
+save_mesh = bool(args.save_mesh or False)
 
 kwargs = {
     'approach': args.approach or 'fixed_mesh',
@@ -98,10 +98,8 @@ if tp.op.approach == 'fixed_mesh':  # TODO: Use 'uniform' approach?
         plt.savefig('screenshots/fluid_speed_offset{:d}_elem{:d}.pdf'.format(op.offset, tp.mesh.num_cells()), bbox_inches='tight')
 else:
     tp.adaptation_loop()
-    if save_plex:
-        plex = tp.mesh._plex
-        viewer = PETSc.Viewer().createHDF5('{:s}_{:d}.h5'.format(op.approach, op.offset), 'w')
-        viewer(plex)
+    if save_mesh:
+        tp.save_meshes('{:s}_{:d}.h5'.format(op.approach, op.offset), op.di)
 
     # Setup figures
     if save_plot:

--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -91,8 +91,6 @@ class AdaptiveProblemBase(object):
         Setup everything which isn't explicitly associated with either the forward or adjoint
         problem.
         """
-        from thetis.callback import CallbackManager
-
         op = self.op
         op.print_debug(op.indent + "SETUP: Building meshes...")
         self.set_meshes(meshes)
@@ -108,8 +106,6 @@ class AdaptiveProblemBase(object):
         self.set_stabilisation()
         op.print_debug(op.indent + "SETUP: Setting boundary conditions...")
         self.set_boundary_conditions()
-        op.print_debug(op.indent + "SETUP: Creating CallbackManagers...")
-        self.callbacks = [CallbackManager() for mesh in self.meshes]
         op.print_debug(op.indent + "SETUP: Creating output files...")
         self.di = create_directory(op.di)
         self.create_outfiles()
@@ -117,10 +113,11 @@ class AdaptiveProblemBase(object):
         self.create_intermediary_spaces()
 
         # Various empty lists and dicts
+        self.callbacks = [None for mesh in self.meshes]
         self.equations = [AttrDict() for mesh in self.meshes]
         self.error_estimators = [AttrDict() for mesh in self.meshes]
-        self.timesteppers = [AttrDict() for mesh in self.meshes]
         self.kernels = [None for mesh in self.meshes]
+        self.timesteppers = [AttrDict() for mesh in self.meshes]
 
     def set_meshes(self, meshes):
         """

--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -422,7 +422,6 @@ class AdaptiveProblemBase(object):
             assert monitors[i] is not None
             args = (Mesh(self.meshes[i].coordinates.copy(deepcopy=True)), monitors[i])
             self.mesh_movers[i] = MeshMover(*args, **kwargs)
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
     def move_mesh(self, i):
         # TODO: documentation
@@ -493,29 +492,23 @@ class AdaptiveProblemBase(object):
         # Compute new physical mesh coordinates
         self.op.print_debug("MESH MOVEMENT: Establishing mesh transformation...")
         self.mesh_movers[i].adapt()
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Update intermediary mesh coordinates
         self.op.print_debug("MESH MOVEMENT: Updating intermediary mesh coordinates...")
         self.intermediary_meshes[i].coordinates.dat.data[:] = self.mesh_movers[i].x.dat.data
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Project a copy of the current solution onto mesh defined on new coordinates
         self.op.print_debug("MESH MOVEMENT: Projecting solutions onto intermediary mesh...")
         self.project_to_intermediary_mesh(i)
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Update physical mesh coordinates
         self.op.print_debug("MESH MOVEMENT: Updating physical mesh coordinates...")
         self.meshes[i].coordinates.dat.data[:] = self.intermediary_meshes[i].coordinates.dat.data
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Copy over projected solution data
         self.op.print_debug("MESH MOVEMENT: Transferring solution data from intermediary mesh...")
         self.copy_data_from_intermediary_mesh(i)  # FIXME: Needs annotation
-        self.op.print_debug("MESH MOVEMENT: Done!")
 
         # Re-interpolate fields
         self.op.print_debug("MESH MOVEMENT: Re-interpolating fields...")
         self.set_fields()
-        self.op.print_debug("MESH MOVEMENT: Done!")

--- a/unsteady/options.py
+++ b/unsteady/options.py
@@ -87,9 +87,7 @@ class CoupledOptions(Options):
         #     ---------------- ------------ ----------------
         self.solver_parameters = {
             "shallow_water": {
-                # "snes_converged_reason": None,
                 "ksp_type": "gmres",
-                # "ksp_converged_reason": None,
                 "pc_type": "fieldsplit",
                 "pc_fieldsplit_type": "multiplicative",
                 "fieldsplit_U_2d": {
@@ -97,8 +95,6 @@ class CoupledOptions(Options):
                     "ksp_max_it": 10000,
                     "ksp_rtol": 1.0e-05,
                     "pc_type": "sor",
-                    # "ksp_view": None,
-                    # "ksp_converged_reason": None,
                 },
                 "fieldsplit_H_2d": {
                     "ksp_type": "preonly",
@@ -106,27 +102,19 @@ class CoupledOptions(Options):
                     "ksp_rtol": 1.0e-05,
                     # "pc_type": "sor",
                     "pc_type": "jacobi",
-                    # "ksp_view": None,
-                    # "ksp_converged_reason": None,
                 },
             },
             "tracer": {
                 "ksp_type": "gmres",
                 "pc_type": "sor",
-                # "ksp_monitor": None,
-                # "ksp_converged_reason": None,
             },
             "sediment": {
                 "ksp_type": "gmres",
                 "pc_type": "sor",
-                # "ksp_monitor": None,
-                # "ksp_converged_reason": None,
             },
             "exner": {
                 "ksp_type": "gmres",
                 "pc_type": "sor",
-                # "ksp_monitor": None,
-                # "ksp_converged_reason": None,
             }
         }
         self.adjoint_solver_parameters.update(self.solver_parameters)

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -324,6 +324,10 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 })
         self.inflow = [self.op.set_inflow(P1_vec) for P1_vec in self.P1_vec]
 
+        # Check CFL criterion
+        if self.op.debug and hasattr(self.op, 'check_cfl_criterion'):
+            self.op.check_cfl_criterion(self)
+
     # --- Stabilisation
 
     def set_stabilisation_step(self, i):
@@ -1404,7 +1408,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
                             for j, H in enumerate(H_window):
                                 if op.hessian_time_combination == 'intersect':
                                     H_window[j] *= op.dt*self.dt_per_mesh
-                                print(H_window[j])
                                 H_windows[j][i].interpolate(H_window[j])
 
                 # Solve step for current mesh iteration

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1214,7 +1214,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
         self.print(80*'=')
         op.print_debug("SOLVE: Entering forward timeloop on mesh {:d}...".format(i))
         if self.num_meshes == 1:
-            msg = "ADJOINT SOLVE mesh  time {:8.2f}  ({:6.2f} seconds)"
+            msg = "ADJOINT SOLVE time {:8.2f}  ({:6.2f} seconds)"
             self.print(msg.format(self.simulation_time, 0.0))
         else:
             msg = "{:2d} {:s}  ADJOINT SOLVE mesh {:2d}/{:2d}  time {:8.2f}  ({:6.2f} seconds)"

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -981,6 +981,14 @@ class AdaptiveProblem(AdaptiveProblemBase):
     # --- Solvers
 
     def add_callbacks(self, i):
+        from thetis.callback import CallbackManager
+
+        # Create a new CallbackManager object on every mesh
+        #   NOTE: This overwrites any pre-existing CallbackManagers
+        self.op.print_debug(self.op.indent + "SETUP: Creating CallbackManagers...")
+        self.callbacks[i] = CallbackManager()
+
+        # Add default callbacks
         if self.op.solve_swe:
             self.callbacks[i].add(VelocityNormCallback(self, i), 'export')
             self.callbacks[i].add(ElevationNormCallback(self, i), 'export')
@@ -1019,19 +1027,17 @@ class AdaptiveProblem(AdaptiveProblemBase):
                         dbcs.append(DirichletBC(self.Q[i], bcs['tracer'][j]['value'], j))
             prob = NonlinearVariationalProblem(ts.F, ts.solution, bcs=dbcs)
             ts.solver = NonlinearVariationalSolver(prob, solver_parameters=ts.solver_parameters, options_prefix="forward_tracer")
-            op.print_debug(op.indent + "SETUP: Adding callbacks on mesh {:d}...".format(i))
         if op.solve_sediment:
             ts = self.timesteppers[i]['sediment']
             dbcs = []
             prob = NonlinearVariationalProblem(ts.F, ts.solution, bcs=dbcs)
             ts.solver = NonlinearVariationalSolver(prob, solver_parameters=ts.solver_parameters, options_prefix="forward_sediment")
-            op.print_debug(op.indent + "SETUP: Adding callbacks on mesh {:d}...".format(i))
         if op.solve_exner:
             ts = self.timesteppers[i]['exner']
             dbcs = []
             prob = NonlinearVariationalProblem(ts.F, ts.solution, bcs=dbcs)
             ts.solver = NonlinearVariationalSolver(prob, solver_parameters=ts.solver_parameters, options_prefix="forward_exner")
-            op.print_debug(op.indent + "SETUP: Adding callbacks on mesh {:d}...".format(i))
+        op.print_debug(op.indent + "SETUP: Adding callbacks on mesh {:d}...".format(i))
         self.add_callbacks(i)
 
     def solve_forward_step(self, i, update_forcings=None, export_func=None, plot_pvd=True):

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1160,7 +1160,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 self.callbacks[i].evaluate(mode='export')
             self.callbacks[i].evaluate(mode='timestep')
         update_forcings(self.simulation_time + op.dt)
-        op.print_debug("Done!")
         self.print(80*'=')
 
     def setup_solver_adjoint(self, i):
@@ -1297,7 +1296,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
                     export_func()
         self.time_kernel.assign(1.0 if self.simulation_time >= self.op.start_time else 0.0)
         update_forcings(self.simulation_time - op.dt)
-        op.print_debug("Done!")
         self.print(80*'=')
 
     # --- Metric
@@ -1474,7 +1472,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])
-            self.print("Done!")
 
             # ---  Setup for next run / logging
 
@@ -1620,7 +1617,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])
-            self.print("Done!")
 
             # ---  Setup for next run / logging
 
@@ -1824,7 +1820,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])
-            self.print("Done!")
 
             # ---  Setup for next run / logging
 

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -103,6 +103,8 @@ class AdaptiveProblem(AdaptiveProblemBase):
         super(AdaptiveProblem, self).__init__(op, nonlinear=nonlinear, **kwargs)
 
     def create_outfiles(self):
+        if not self.op.plot_pvd:
+            return
         if self.op.solve_swe:
             self.solution_file = File(os.path.join(self.di, 'solution.pvd'))
             self.adjoint_solution_file = File(os.path.join(self.di, 'adjoint_solution.pvd'))
@@ -1543,7 +1545,8 @@ class AdaptiveProblem(AdaptiveProblemBase):
             Publishing (2016), p.4055--4074, DOI 10.1007/s00024-016-1412-y.
         """
         op = self.op
-        self.indicator_file = File(os.path.join(self.di, 'indicator.pvd'))
+        if op.plot_pvd:
+            self.indicator_file = File(os.path.join(self.di, 'indicator.pvd'))
         for n in range(op.num_adapt):
             self.outer_iteration = n
 
@@ -1620,8 +1623,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
             # metric_file = File(os.path.join(self.di, 'metric.pvd'))
             complexities = []
             for i, M in enumerate(metrics):
-                self.indicator_file._topology = None
-                self.indicator_file.write(self.indicators[i]['dwp'])
+                if op.plot_pvd:
+                    self.indicator_file._topology = None
+                    self.indicator_file.write(self.indicators[i]['dwp'])
                 # metric_file._topology = None
                 # metric_file.write(M)
                 complexities.append(metric_complexity(M))
@@ -1667,7 +1671,8 @@ class AdaptiveProblem(AdaptiveProblemBase):
     def run_dwr(self, **kwargs):
         # TODO: doc
         op = self.op
-        self.indicator_file = File(os.path.join(self.di, 'indicator.pvd'))
+        if op.plot_pvd:
+            self.indicator_file = File(os.path.join(self.di, 'indicator.pvd'))
         for n in range(op.num_adapt):
             self.outer_iteration = n
 
@@ -1823,8 +1828,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
             # metric_file = File(os.path.join(self.di, 'metric.pvd'))
             complexities = []
             for i, M in enumerate(metrics):
-                self.indicator_file._topology = None
-                self.indicator_file.write(self.indicators[i]['dwr'])
+                if op.plot_pvd:
+                    self.indicator_file._topology = None
+                    self.indicator_file.write(self.indicators[i]['dwr'])
                 # metric_file._topology = None
                 # metric_file.write(M)
                 complexities.append(metric_complexity(M))

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1406,6 +1406,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
                             for j, H in enumerate(H_window):
                                 if op.hessian_time_combination == 'intersect':
                                     H_window[j] *= op.dt*self.dt_per_mesh
+                                print(H_window[j])
                                 H_windows[j][i].interpolate(H_window[j])
 
                 # Solve step for current mesh iteration

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1428,7 +1428,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
                                 H_windows[j][i].interpolate(H_window[j])
 
                 # Solve step for current mesh iteration
-
                 self.setup_solver_forward(i)
                 self.solve_forward_step(i, export_func=export_func, update_forcings=update_forcings, plot_pvd=op.plot_pvd)
 
@@ -1488,7 +1487,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
             self.print("\nStarting mesh adaptation for iteration {:d}...".format(n+1))
             for i, M in enumerate(metrics):
                 self.print("Adapting mesh {:d}/{:d}...".format(i+1, self.num_meshes))
-                self.meshes[i] = pragmatic_adapt(self.meshes[i], M, op=op)
+                self.meshes[i] = pragmatic_adapt(self.meshes[i], M)
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])
@@ -1633,7 +1632,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
             self.print("\nStarting mesh adaptation for iteration {:d}...".format(n+1))
             for i, M in enumerate(metrics):
                 self.print("Adapting mesh {:d}/{:d}...".format(i+1, self.num_meshes))
-                self.meshes[i] = pragmatic_adapt(self.meshes[i], M, op=op)
+                self.meshes[i] = pragmatic_adapt(self.meshes[i], M)
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])
@@ -1836,7 +1835,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
             self.print("\nStarting mesh adaptation for iteration {:d}...".format(n+1))
             for i, M in enumerate(metrics):
                 self.print("Adapting mesh {:d}/{:d}...".format(i+1, self.num_meshes))
-                self.meshes[i] = pragmatic_adapt(self.meshes[i], M, op=op)
+                self.meshes[i] = pragmatic_adapt(self.meshes[i], M)
             del metrics
             self.num_cells.append([mesh.num_cells() for mesh in self.meshes])
             self.num_vertices.append([mesh.num_vertices() for mesh in self.meshes])

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1055,6 +1055,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
         if export_func is not None:
             export_func()
         self.callbacks[i].evaluate(mode='export')
+        self.callbacks[i].evaluate(mode='timestep')
 
         # We need to project to P1 for vtk outputs
         if op.solve_swe and plot_pvd:
@@ -1131,7 +1132,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
             # Export
             self.iteration += 1
             self.simulation_time += op.dt
-            self.callbacks[i].evaluate(mode='timestep')
             if self.iteration % op.dt_per_export == 0:
                 cpu_time = perf_counter() - cpu_timestamp
                 if self.num_meshes == 1:
@@ -1158,6 +1158,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 if export_func is not None:
                     export_func()
                 self.callbacks[i].evaluate(mode='export')
+            self.callbacks[i].evaluate(mode='timestep')
         update_forcings(self.simulation_time + op.dt)
         op.print_debug("Done!")
         self.print(80*'=')

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -326,7 +326,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
 
         # Check CFL criterion
         if self.op.debug and hasattr(self.op, 'check_cfl_criterion'):
-            self.op.check_cfl_criterion(self)
+            self.op.check_cfl_criterion(self, error_factor=None)
+            # TODO: parameter for error_factor, defaulted by timestepper choice
+            # TODO: allow t-adaptation in a given subinterval
 
     # --- Stabilisation
 

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -67,6 +67,17 @@ class AdaptiveProblem(AdaptiveProblemBase):
             for model in op.solver_parameters:
                 op.solver_parameters[model]['snes_type'] = 'ksponly'
                 op.adjoint_solver_parameters[model]['snes_type'] = 'ksponly'
+        if op.debug:
+            for model in op.solver_parameters:
+                op.solver_parameters[model]['ksp_converged_reason'] = None
+                op.solver_parameters[model]['snes_converged_reason'] = None
+                op.adjoint_solver_parameters[model]['ksp_converged_reason'] = None
+                op.adjoint_solver_parameters[model]['snes_converged_reason'] = None
+                if op.debug_mode == 'full':
+                    op.solver_parameters[model]['ksp_monitor'] = None
+                    op.solver_parameters[model]['snes_monitor'] = None
+                    op.adjoint_solver_parameters[model]['ksp_monitor'] = None
+                    op.adjoint_solver_parameters[model]['snes_monitor'] = None
         self.tracer_options = [AttrDict() for i in range(op.num_meshes)]
         self.sediment_options = [AttrDict() for i in range(op.num_meshes)]
         self.exner_options = [AttrDict() for i in range(op.num_meshes)]
@@ -1050,8 +1061,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
             self.print(msg.format(self.simulation_time, 0.0))
         else:
             msg = "{:2d} {:s} FORWARD SOLVE mesh {:2d}/{:2d}  time {:8.2f}  ({:6.2f}) seconds"
-            self.print(msg.format(self.outer_iteration, '  '*i, i+1,
-                                  self.num_meshes, self.simulation_time, 0.0))
+            indent = '' if op.debug else '  '*i
+            self.print(msg.format(self.outer_iteration, indent, i+1, self.num_meshes,
+                                  self.simulation_time, 0.0))
         cpu_timestamp = perf_counter()
 
         # Callbacks
@@ -1143,8 +1155,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 if self.num_meshes == 1:
                     self.print(msg.format(self.simulation_time, cpu_time))
                 else:
-                    self.print(msg.format(self.outer_iteration, '  '*i, i+1,
-                                          self.num_meshes, self.simulation_time, cpu_time))
+                    indent = '' if op.debug else '  '*i
+                    self.print(msg.format(self.outer_iteration, indent, i+1, self.num_meshes,
+                                          self.simulation_time, cpu_time))
                 cpu_timestamp = perf_counter()
                 if op.solve_swe and plot_pvd:
                     u, eta = self.fwd_solutions[i].split()
@@ -1223,9 +1236,10 @@ class AdaptiveProblem(AdaptiveProblemBase):
             msg = "ADJOINT SOLVE time {:8.2f}  ({:6.2f} seconds)"
             self.print(msg.format(self.simulation_time, 0.0))
         else:
+            indent = '' if op.debug else '  '*i
             msg = "{:2d} {:s}  ADJOINT SOLVE mesh {:2d}/{:2d}  time {:8.2f}  ({:6.2f} seconds)"
-            self.print(msg.format(self.outer_iteration, '  '*i, i+1,
-                                  self.num_meshes, self.simulation_time, 0.0))
+            self.print(msg.format(self.outer_iteration, indent, i+1, self.num_meshes,
+                                  self.simulation_time, 0.0))
         cpu_timestamp = perf_counter()
 
         # Callbacks
@@ -1288,8 +1302,9 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 if self.num_meshes == 1:
                     self.print(msg.format(self.simulation_time, cpu_time))
                 else:
-                    self.print(msg.format(self.outer_iteration, '  '*i, i+1,
-                                          self.num_meshes, self.simulation_time, cpu_time))
+                    indent = '' if op.debug else '  '*i
+                    self.print(msg.format(self.outer_iteration, indent, i+1, self.num_meshes,
+                                          self.simulation_time, cpu_time))
                 if op.solve_swe and plot_pvd:
                     z, zeta = self.adj_solutions[i].split()
                     proj_z.project(z)

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1734,7 +1734,7 @@ class AdaptiveProblem(AdaptiveProblemBase):
                 fwd_solutions_step_old = []
                 adj_solutions_step = []
                 enriched_adj_solutions_step = []
-                tm = dmhooks.get_transfer_manager(self.meshes[i]._plex)
+                tm = dmhooks.get_transfer_manager(self.get_plex(i))
 
                 # --- Setup forward solver for enriched problem
 

--- a/unsteady/solver.py
+++ b/unsteady/solver.py
@@ -1301,7 +1301,6 @@ class AdaptiveProblem(AdaptiveProblemBase):
             # Increment counters
             self.iteration -= 1
             self.simulation_time -= op.dt
-            self.callbacks[i].evaluate(mode='timestep')
 
             # Export
             if self.iteration % op.dt_per_export == 0:

--- a/unsteady/solver_adjoint.py
+++ b/unsteady/solver_adjoint.py
@@ -22,7 +22,10 @@ class AdaptiveDiscreteAdjointProblem(AdaptiveProblem):
     def clear_tape(self):
         self.tape.clear_tape()
 
-    # TODO: just call `solve_adjoint` (once merged)
+    def solve_adjoint(self, scaling=1.0):
+        """Solve the discrete adjoint problem for some quantity of interest."""
+        J = self.quantity_of_interest()
+        return solve_adjoint(J, adj_value=scaling)
 
     def compute_gradient(self, controls, scaling=1.0):
         """Compute the gradient of the quantity of interest with respect to a list of controls."""

--- a/unsteady/swe/tsunami/options.py
+++ b/unsteady/swe/tsunami/options.py
@@ -344,3 +344,14 @@ class TsunamiOptions(CoupledOptions):
     def detide(self, gauge):
         """To be implemented in subclass."""
         raise NotImplementedError
+
+    def check_cfl_criterion(self, prob):
+        for i, (mesh, P0, bathymetry) in enumerate(zip(prob.meshes, prob.P0, prob.bathymetry)):
+            self.print_debug("INIT: Computing CFL number on mesh {:d}...".format(i))
+            b = bathymetry.vector().gather().max()
+            g = self.g.values()[0]
+            celerity = np.sqrt(g*b)
+            dx = interpolate(CellDiameter(mesh), P0).vector().gather().min()
+            cfl = celerity*self.dt/dx
+            msg = "INIT:   dx = {:.4e}  dt = {:.4e}  CFL number = {:.4e} {:1s} 1"
+            self.print_debug(msg.format(dx, self.dt, cfl, '<' if cfl < 1 else '>'))

--- a/unsteady/swe/tsunami/options.py
+++ b/unsteady/swe/tsunami/options.py
@@ -226,21 +226,7 @@ class TsunamiOptions(CoupledOptions):
         return interpolate(2*self.Omega*sin(radians(lat)), fs)
 
     def set_qoi_kernel(self, prob, i):
-        # b = self.ball(prob.meshes[i], source=False)
-        # b = self.circular_bump(prob.meshes[i], source=False)
-        b = self.gaussian(prob.meshes[i], source=False)
-
-        # TODO: Normalise by area computed on fine reference mesh
-        # area = assemble(b*dx)
-        # area_fine_mesh = ...
-        # rescaling = Constant(1.0 if np.allclose(area, 0.0) else area_fine_mesh/area)
-        rescaling = Constant(1.0)
-
-        prob.kernels[i] = Function(prob.V[i], name="QoI kernel")
-        kernel_u, kernel_eta = prob.kernels[i].split()
-        kernel_u.rename("QoI kernel (velocity component)")
-        kernel_eta.rename("QoI kernel (elevation component)")
-        kernel_eta.interpolate(rescaling*b)
+        raise NotImplementedError("Should be implemented in derived class.")
 
     def set_terminal_condition(self, prob):  # TODO: For hazard case
         prob.adj_solutions[-1].assign(0.0)

--- a/unsteady/swe/tsunami/options.py
+++ b/unsteady/swe/tsunami/options.py
@@ -111,7 +111,6 @@ class TsunamiOptions(CoupledOptions):
         lon, lat, elev = dat or self.read_bathymetry_file(**kwargs)
         self.print_debug("INIT: Creating bathymetry interpolator...")
         bath_interp = si.RectBivariateSpline(lat, lon, elev)
-        self.print_debug("INIT: Done!")
 
         # Insert interpolated data onto nodes of *problem domain space*
         self.print_debug("INIT: Interpolating bathymetry...")
@@ -121,13 +120,11 @@ class TsunamiOptions(CoupledOptions):
                                      northern=northern, force_longitude=force_longitude)
             bathymetry.dat.data[i] -= bath_interp(lat, lon)
             self.print_debug(msg.format(xy[0], xy[1], bathymetry.dat.data[i]/1000), mode='full')
-        self.print_debug("INIT: Done!")
 
         # Cap bathymetry to enforce a minimum depth
         self.print_debug("INIT: Capping bathymetry...")  # TODO: Should we really be doing this?
         if self.bathymetry_cap is not None:
             bathymetry.interpolate(max_value(self.bathymetry_cap, bathymetry))
-        self.print_debug("INIT: Done!")
 
         return bathymetry
 
@@ -158,7 +155,6 @@ class TsunamiOptions(CoupledOptions):
         self.print_debug("INIT: Creating surface interpolator...")
         lon, lat, elev = dat or self.read_surface_file(**kwargs)
         surf_interp = si.RectBivariateSpline(lat, lon, elev)
-        self.print_debug("INIT: Done!")
 
         # Insert interpolated data onto nodes of *problem domain space*
         self.print_debug("INIT: Interpolating initial surface...")
@@ -168,7 +164,6 @@ class TsunamiOptions(CoupledOptions):
                                      northern=northern, force_longitude=force_longitude)
             initial_surface.dat.data[i] = surf_interp(lat, lon)
             self.print_debug(msg.format(xy[0], xy[1], initial_surface.dat.data[i]), mode='full')
-        self.print_debug("INIT: Done!")
 
         return initial_surface
 
@@ -189,7 +184,6 @@ class TsunamiOptions(CoupledOptions):
         u, eta = prob.fwd_solutions[0].split()
         u.assign(0.0)  # (Naively) assume zero initial velocity
         eta.interpolate(surf)  # Initial surface from inversion data
-        self.print_debug("INIT: Done!")
 
         # Subtract from the bathymetry field
         self.subtract_surface_from_bathymetry(prob, surf=surf)
@@ -224,7 +218,6 @@ class TsunamiOptions(CoupledOptions):
         # Project updated bathymetry onto each mesh
         for i in range(self.num_meshes):
             prob.bathymetry[i].project(b)
-        self.print_debug("INIT: Done!")
 
     def set_coriolis(self, fs):
         if not self.rotational:

--- a/unsteady/swe/tsunami/options.py
+++ b/unsteady/swe/tsunami/options.py
@@ -114,12 +114,12 @@ class TsunamiOptions(CoupledOptions):
 
         # Insert interpolated data onto nodes of *problem domain space*
         self.print_debug("INIT: Interpolating bathymetry...")
-        msg = "    Coordinates ({:.1f}, {:.1f}) Bathymetry {:.3f} km"
+        # msg = "    Coordinates ({:.1f}, {:.1f}) Bathymetry {:.3f} km"
         for i, xy in enumerate(fs.mesh().coordinates.dat.data):
             lon, lat = utm_to_lonlat(xy[0], xy[1], self.force_zone_number,
                                      northern=northern, force_longitude=force_longitude)
             bathymetry.dat.data[i] -= bath_interp(lat, lon)
-            self.print_debug(msg.format(xy[0], xy[1], bathymetry.dat.data[i]/1000), mode='full')
+            # self.print_debug(msg.format(xy[0], xy[1], bathymetry.dat.data[i]/1000), mode='full')
 
         # Cap bathymetry to enforce a minimum depth
         self.print_debug("INIT: Capping bathymetry...")  # TODO: Should we really be doing this?
@@ -158,12 +158,12 @@ class TsunamiOptions(CoupledOptions):
 
         # Insert interpolated data onto nodes of *problem domain space*
         self.print_debug("INIT: Interpolating initial surface...")
-        msg = "    Coordinates ({:.1f}, {:.1f}) Surface {:.3f} m"
+        # msg = "    Coordinates ({:.1f}, {:.1f}) Surface {:.3f} m"
         for i, xy in enumerate(fs.mesh().coordinates.dat.data):
             lon, lat = utm_to_lonlat(xy[0], xy[1], self.force_zone_number,
                                      northern=northern, force_longitude=force_longitude)
             initial_surface.dat.data[i] = surf_interp(lat, lon)
-            self.print_debug(msg.format(xy[0], xy[1], initial_surface.dat.data[i]), mode='full')
+            # self.print_debug(msg.format(xy[0], xy[1], initial_surface.dat.data[i]), mode='full')
 
         return initial_surface
 

--- a/unsteady/swe/tsunami/options.py
+++ b/unsteady/swe/tsunami/options.py
@@ -345,7 +345,7 @@ class TsunamiOptions(CoupledOptions):
         """To be implemented in subclass."""
         raise NotImplementedError
 
-    def check_cfl_criterion(self, prob):
+    def check_cfl_criterion(self, prob, error_factor=None):
         for i, (mesh, P0, bathymetry) in enumerate(zip(prob.meshes, prob.P0, prob.bathymetry)):
             self.print_debug("INIT: Computing CFL number on mesh {:d}...".format(i))
             b = bathymetry.vector().gather().max()
@@ -355,3 +355,9 @@ class TsunamiOptions(CoupledOptions):
             cfl = celerity*self.dt/dx
             msg = "INIT:   dx = {:.4e}  dt = {:.4e}  CFL number = {:.4e} {:1s} 1"
             self.print_debug(msg.format(dx, self.dt, cfl, '<' if cfl < 1 else '>'))
+            if error_factor is not None and cfl >= error_factor:
+                if np.isclose(error_factor, 1.0):
+                    raise ValueError("CFL criterion not met! (CFL number {:.4e})".format(cfl))
+                else:
+                    msg = "Relaxed CFL criterion not met! (CFL number {:.4e} > {:.4e})"
+                    raise ValueError(msg.format(cfl, error_factor))

--- a/unsteady/swe/tsunami/solver.py
+++ b/unsteady/swe/tsunami/solver.py
@@ -19,26 +19,18 @@ class AdaptiveTsunamiProblem(AdaptiveProblem):
       * Extract free surface elevation timeseries for all gauges stored in the :class:`Options`
         parameter class.
     """
-    # TODO: Is `extension` redundant?
-    def __init__(self, *args, extension=None, nonlinear=False, **kwargs):
-        self.extension = extension
+    def __init__(self, *args, nonlinear=False, **kwargs):
         super(AdaptiveTsunamiProblem, self).__init__(*args, nonlinear=nonlinear, **kwargs)
         try:
-            assert not self.op.solve_tracer
+            assert not (self.op.solve_tracer or self.op.solve_sediment or self.op.solve_exner)
         except AssertionError:
-            raise ValueError("This class is for problems with no tracer component.")
+            raise ValueError("This class is for problems with hydrodynamics only.")
 
     def add_callbacks(self, i):
         super(AdaptiveTsunamiProblem, self).add_callbacks(i)
-        gauges = list(self.op.gauges.keys())
-        for gauge in gauges:
-            try:
-                self.bathymetry[i].at(self.op.gauges[gauge]["coords"])
-            except PointNotInDomainError:
-                print_output("Gauge {:s} not in domain! Removing from gauge list.".format(gauge))
-                self.op.gauges.pop(gauge)
-                continue
-            self.callbacks[i].add(GaugeCallback(self, i, gauge), 'export')
+        # gauges = list(self.op.gauges.keys())
+        # for gauge in gauges:
+        #     self.callbacks[i].add(GaugeCallback(self, i, gauge), 'export')
         self.get_qoi_kernels(i)
         self.callbacks[i].add(QoICallback(self, i), 'timestep')
 
@@ -46,12 +38,12 @@ class AdaptiveTsunamiProblem(AdaptiveProblem):
         self.qoi = sum(c['timestep']['qoi'].time_integrate() for c in self.callbacks)
         return self.qoi
 
-    def save_gauge_data(self, fname):
-        fname = "diagnostic_gauges_{:s}.hdf5".format(fname)
-        with h5py.File(os.path.join(self.di, fname), 'w') as f:
-            for gauge in self.op.gauges:
-                timeseries = []
-                for i in range(self.num_meshes):
-                    timeseries.extend(self.callbacks[i]['export'][gauge].timeseries)
-                f.create_dataset(gauge, data=np.array(timeseries))
-            f.create_dataset("num_cells", data=np.array(self.num_cells[-1]))
+    # def save_gauge_data(self, fname):
+    #     fname = "diagnostic_gauges_{:s}.hdf5".format(fname)
+    #     with h5py.File(os.path.join(self.di, fname), 'w') as f:
+    #         for gauge in self.op.gauges:
+    #             timeseries = []
+    #             for i in range(self.num_meshes):
+    #                 timeseries.extend(self.callbacks[i]['export'][gauge].timeseries)
+    #             f.create_dataset(gauge, data=np.array(timeseries))
+    #         f.create_dataset("num_cells", data=np.array(self.num_cells[-1]))

--- a/unsteady/swe/tsunami/solver.py
+++ b/unsteady/swe/tsunami/solver.py
@@ -34,8 +34,15 @@ class AdaptiveTsunamiProblem(AdaptiveProblem):
         self.get_qoi_kernels(i)
         self.callbacks[i].add(QoICallback(self, i), 'timestep')
 
+    def get_qoi_timeseries(self):
+        self.qoi_timeseries = []
+        for c in self.callbacks:
+            self.qoi_timeseries.extend(c['timestep']['qoi'].timeseries)
+        return self.qoi_timeseries
+
     def quantity_of_interest(self):
-        self.qoi = sum(c['timestep']['qoi'].time_integrate() for c in self.callbacks)
+        self.get_qoi_timeseries()
+        self.qoi = sum(self.qoi_timeseries)
         return self.qoi
 
     # def save_gauge_data(self, fname):

--- a/unsteady/test_cases/balzano/makefile
+++ b/unsteady/test_cases/balzano/makefile
@@ -3,9 +3,7 @@ all: fixed_mesh
 fixed_mesh:
 	@echo "Solving inundated beach problem on a fixed mesh..."
 	@python3 run_fixed_mesh.py
-	@echo "Done!"
 
 moving_mesh:
 	@echo "Solving inundated beach problem on a moving mesh..."
 	@python3 run_moving_mesh.py
-	@echo "Done!"

--- a/unsteady/test_cases/beach_slope/hydro_fns.py
+++ b/unsteady/test_cases/beach_slope/hydro_fns.py
@@ -176,7 +176,7 @@ def export_final_state(inputdir, uv, elev,):
     chk.store(elev, name="elevation")
     th.File(inputdir + '/elevationout.pvd').write(elev)
     chk.close()
-    
+
     plex = elev.function_space().mesh()._plex
     viewer = PETSc.Viewer().createHDF5(inputdir + '/myplex.h5', 'w')
     viewer(plex)

--- a/unsteady/test_cases/beach_wall/hydro_fns.py
+++ b/unsteady/test_cases/beach_wall/hydro_fns.py
@@ -176,7 +176,7 @@ def export_final_state(inputdir, uv, elev,):
     chk.store(elev, name="elevation")
     th.File(inputdir + '/elevationout.pvd').write(elev)
     chk.close()
-    
+
     plex = elev.function_space().mesh()._plex
     viewer = PETSc.Viewer().createHDF5(inputdir + '/myplex.h5', 'w')
     viewer(plex)

--- a/unsteady/test_cases/rossby_wave/makefile
+++ b/unsteady/test_cases/rossby_wave/makefile
@@ -5,23 +5,19 @@ all: fixed_mesh
 fixed_mesh:
 	@echo "Solving equatorial Rossby wave problem on a fixed mesh..."
 	@python3 run_fixed_mesh.py
-	@echo "Done!"
 
 uniform:
 	@echo "Solving equatorial Rossby wave problem on a hierarchy of fixed meshes..."
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 1
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 2
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 4
-	@echo "Done!"
 
 refined_equator:
 	@echo "Solving equatorial Rossby wave problem on a hierarchy of fixed meshes refined around the equator..."
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 1 -refine_equator 1
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 2 -refine_equator 1
 	@python3 run_fixed_mesh.py -debug 1 -n_coarse 4 -refine_equator 1
-	@echo "Done!"
 
 moving_mesh:
 	@echo "Solving equatorial Rossby wave problem on a moving mesh..."
 	@python3 run_moving_mesh.py
-	@echo "Done!"

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -9,7 +9,6 @@ square: uniform_square plot_square print_square
 mesh:
 	@echo "Generating Delauney mesh of circular domain..."
 	@gmsh -2 circle.geo
-	@echo "Done!"
 
 # --- Uniform convergence
 
@@ -21,7 +20,6 @@ uniform_circle:
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 1
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 2
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 3
-	@echo "Done!"
 
 uniform_square:
 	@echo "Solving solid body rotation problem on square domain..."
@@ -29,7 +27,6 @@ uniform_square:
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 1
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 2
 	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 3
-	@echo "Done!"
 
 print_circle:
 	@cat outputs/fixed_mesh/circle_1.log
@@ -48,13 +45,11 @@ plot: plot_circle plot_square
 plot_circle:
 	@echo "Plotting convergence for circular domain..."
 	@python3 plot_convergence.py -mesh_type circle
-	@echo "Done!"
 	@gio open outputs/fixed_mesh/convergence_circle.pdf
 
 plot_square:
 	@echo "Plotting convergence for square domain..."
 	@python3 plot_convergence.py -mesh_type square
-	@echo "Done!"
 	@gio open outputs/fixed_mesh/convergence_square.pdf
 
 # --- Cleanup
@@ -62,4 +57,3 @@ plot_square:
 clean:
 	@echo "Cleaning directory..."
 	@rm -Rf *.msh
-	@echo "Done!"

--- a/unsteady/test_cases/solid_body_rotation/run_adjoint.py
+++ b/unsteady/test_cases/solid_body_rotation/run_adjoint.py
@@ -94,4 +94,3 @@ tp_continuous = UnannotatedTracerProblem(op)
 tp_continuous.set_initial_condition()  # Adjoint propagation is driven by reverse flow
 print_output("Running continuous adjoint model...")
 tp_continuous.solve_adjoint()
-print_output("Done!")

--- a/unsteady/test_cases/spaceship/makefile
+++ b/unsteady/test_cases/spaceship/makefile
@@ -3,15 +3,12 @@ all: clean mesh plot
 mesh:
 	@echo "Generating Delauney mesh of 'spaceship' domain..."
 	@gmsh -2 spaceship.geo
-	@echo "Done!"
 
 plot:
 	@echo "Plotting setup of 'spaceship' problem..."
 	@python3 plot_setup.py
 	@python3 plot_tidal_forcing.py
-	@echo "Done!"
 
 clean:
 	@echo "Cleaning directory..."
 	@rm -Rf *.msh
-	@echo "Done!"

--- a/unsteady/test_cases/trench_1d/trench_hydro.py
+++ b/unsteady/test_cases/trench_1d/trench_hydro.py
@@ -34,7 +34,7 @@ def export_final_state(inputdir, uv, elev):  # TODO: Put into io?
     chk.store(elev, name="elevation")
     File(inputdir + '/elevationout.pvd').write(elev)
     chk.close()
-    
+
     plex = elev.function_space().mesh()._plex
     viewer = PETSc.Viewer().createHDF5(inputdir + '/myplex.h5', 'w')
     viewer(plex)

--- a/unsteady/test_cases/trench_slant/hydro_fns.py
+++ b/unsteady/test_cases/trench_slant/hydro_fns.py
@@ -149,7 +149,7 @@ def export_final_state(inputdir, uv, elev):  # TODO: Put into io?
     chk.store(elev, name="elevation")
     th.File(inputdir + '/elevationout.pvd').write(elev)
     chk.close()
-    
+
     plex = elev.function_space().mesh()._plex
     viewer = PETSc.Viewer().createHDF5(inputdir + '/myplex.h5', 'w')
     viewer(plex)

--- a/unsteady/test_cases/turbine_array/makefile
+++ b/unsteady/test_cases/turbine_array/makefile
@@ -3,14 +3,11 @@ all: clean mesh plot
 mesh:
 	@echo "Generating Delauney mesh of turbine array domain..."
 	@gmsh -2 channel.geo
-	@echo "Done!"
 
 plot:
 	@echo "Plotting mesh for turbine array problem..."
 	@python3 plot_mesh.py
-	@echo "Done!"
 
 clean:
 	@echo "Cleaning directory..."
 	@rm -rf *.msh
-	@echo "Done!"


### PR DESCRIPTION
Updates for time-dependent mesh adaptation under Pragmatic.

The application scripts in `case_studies/tohoku/hazard/` all run fine with the default settings, although `run_dwr` requires an awful lot of RAM due to considering a 2 level `MeshHierarchy` on 12 different adapted meshes (and all the associated function spaces/fields/equations...).

Misc functionality relating to callbacks and I/O also extended/fixed.

