### PR TITLE
Script for installing Python 3.7 from binary

### DIFF
--- a/install/install_docker.sh
+++ b/install/install_docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker pull firedrakeproject/firedrake
+# docker run -v $HOME:$HOME -it firedrakeproject/firedrake

--- a/install/install_firedrake.sh
+++ b/install/install_firedrake.sh
@@ -45,6 +45,7 @@ fi
 echo "PETSC_ARCH="$PETSC_ARCH
 echo "FIREDRAKE_ENV="$FIREDRAKE_ENV
 echo "FIREDRAKE_DIR="$FIREDRAKE_DIR
+echo "python3="$(which python3)
 echo "Are these settings okay? Press enter to continue."
 read chk
 

--- a/install/install_firedrake.sh
+++ b/install/install_firedrake.sh
@@ -38,7 +38,7 @@ echo "MPICXX="$MPICXX
 echo "MPIF90="$MPIF90
 echo "MPIEXEC="$MPIEXEC
 echo "PETSC_DIR="$PETSC_DIR
-if [ ! -f "$PETSC_DIR" ]; then
+if [ ! -e "$PETSC_DIR" ]; then
     echo "$PETSC_DIR does not exist. Please run install_petsc.sh."
     exit 1
 fi

--- a/install/install_firedrake_no_adapt.sh
+++ b/install/install_firedrake_no_adapt.sh
@@ -31,6 +31,7 @@ echo "MPIF90="$MPIF90
 echo "MPIEXEC="$MPIEXEC
 echo "FIREDRAKE_ENV="$FIREDRAKE_ENV
 echo "FIREDRAKE_DIR="$FIREDRAKE_DIR
+echo "python3="$(which python3)
 echo "Are these settings okay? Press enter to continue."
 read chk
 

--- a/install/install_firedrake_no_adapt.sh
+++ b/install/install_firedrake_no_adapt.sh
@@ -9,7 +9,7 @@
 unset PYTHONPATH
 
 # Check SOFTWARE environment variable
-if [ ! -f "$SOFTWARE" ]; then
+if [ ! -e "$SOFTWARE" ]; then
     echo "SOFTWARE environment variable $SOFTWARE does not exist."
     exit 1
 fi

--- a/install/install_petsc.sh
+++ b/install/install_petsc.sh
@@ -10,7 +10,7 @@
 # ====================================================================== #
 
 # Set environment variables
-if [ ! -f "$SOFTWARE" ]; then
+if [ ! -e "$SOFTWARE" ]; then
     echo "SOFTWARE environment variable $SOFTWARE does not exist."
     exit 1
 fi

--- a/install/install_python3.sh
+++ b/install/install_python3.sh
@@ -32,7 +32,7 @@ cd Python-3.7.4
 
 # Configure and install
 ./configure --enable-optimizations
-make -j nproc
+make -j $(nproc)
 sudo make altinstall
 
 # Alias for convenience

--- a/install/install_python3.sh
+++ b/install/install_python3.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# ====================================================================== #
+# Bash script for installing Python 3.7.4., assuming the operating       #
+# system is Ubuntu. (Firedrake requires Python 3.6 or later.)            #
+#                                                                        #
+# If running on a fresh Ubuntu OS (such as on a newly spun-up virtual    #
+# machine) that doesn't have Python 3.6 or later then this script        #
+# should be run first, before the `install_firedrake.sh` script.         #
+#                                                                        #
+# This script is particularly useful if the system has anaconda          #
+# installed and the user doesn't want to permanently replace it.         #
+#                                                                        #
+#                                       Joe Wallwork, 3rd September 2020 #
+# ====================================================================== #
+
+# Check existence of SOFTWARE environment variable
+if [ ! -e "$SOFTWARE" ]; then
+    echo "SOFTWARE environment variable $SOFTWARE does not exist."
+    exit 1
+fi
+cd $SOFTWARE
+
+# Install dependencies
+sudo apt update
+sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
+
+# Download binary and decompress
+wget https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tgz
+tar -xf Python-3.7.4.tgz
+cd Python-3.7.4
+
+# Configure and install
+./configure --enable-optimizations
+make -j nproc
+sudo make altinstall
+
+# Alias for convenience
+alias python3='python3.7'

--- a/install/makefile
+++ b/install/makefile
@@ -1,13 +1,16 @@
-all: firedrake
+all: compilers petsc firedrake
 
 compilers:
 	source install_compilers.sh
 
-petsc: compilers
+python3:
+	source install_python3.sh
+
+petsc:
 	source install_petsc.sh
 
-firedrake: petsc
+firedrake:
 	source install_firedrake.sh
 
-basic: compilers
+basic:
 	source install_firedrake_no_adapt.sh

--- a/install/setup_docker.sh
+++ b/install/setup_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo groupadd docker
+sudo usermod -aG docker ${USER}
+
+# Log out and log back in
+exit 0


### PR DESCRIPTION
I recently tried installing on a fresh VM which had a default Python with anaconda with version less than that needed by Firedrake.

The script in this PR enables you to install from binary and set an alias.