### PR TITLE
Updates for solid body rotation test case

### DIFF
--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -623,14 +623,14 @@ class AdaptiveProblemBase(object):
             F -= 0.5*dt*inner(test, self.op.get_velocity(coords, t))*dx
 
             params = {
-                'mat_type': 'aij',
-                'snes_type': 'newtonls',
-                'snes_rtol': 1.0e-03,
-                # 'ksp_type': 'gmres',
-                'ksp_type': 'preonly',
-                # 'pc_type': 'sor',
-                'pc_type': 'lu',
-                'pc_type_factor_mat_solver_type': 'mumps',
+                # 'mat_type': 'aij',
+                'snes_type': 'ksponly',  # TODO: Reformulate as a linear system so not needed
+                'snes_rtol': 1.0e-08,
+                'ksp_type': 'gmres',
+                # 'ksp_type': 'preonly',
+                'pc_type': 'sor',
+                # 'pc_type': 'lu',
+                # 'pc_type_factor_mat_solver_type': 'mumps',
             }
             solve(F == 0, coords, solver_parameters=params)
 

--- a/unsteady/base.py
+++ b/unsteady/base.py
@@ -623,14 +623,14 @@ class AdaptiveProblemBase(object):
             F -= 0.5*dt*inner(test, self.op.get_velocity(coords, t))*dx
 
             params = {
-                # 'mat_type': 'aij',
+                'mat_type': 'aij',
                 'snes_type': 'ksponly',  # TODO: Reformulate as a linear system so not needed
-                'snes_rtol': 1.0e-08,
-                'ksp_type': 'gmres',
-                # 'ksp_type': 'preonly',
-                'pc_type': 'sor',
-                # 'pc_type': 'lu',
-                # 'pc_type_factor_mat_solver_type': 'mumps',
+                'snes_rtol': 1.0e-03,
+                # 'ksp_type': 'gmres',
+                'ksp_type': 'preonly',
+                # 'pc_type': 'sor',
+                'pc_type': 'lu',
+                'pc_type_factor_mat_solver_type': 'mumps',
             }
             solve(F == 0, coords, solver_parameters=params)
 
@@ -644,7 +644,7 @@ class AdaptiveProblemBase(object):
         num_inverted = len(r[r < 0])
         if num_inverted > 0:
             import warnings
-            warnings.warn("WARNING: Mesh has {:d} inverted element(s)!".format(num_inverted))
+            warnings.warn("Mesh has {:d} inverted element(s)!".format(num_inverted))
 
     def move_mesh_monge_ampere(self, i):  # TODO: Annotation
         """

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -3,10 +3,6 @@ all: clean mesh
 
 # --- Mesh
 
-circle: uniform_circle plot_circle print_circle
-
-square: uniform_square plot_square print_square
-
 mesh:
 	@echo "Generating Delauney mesh of circular domain..."
 	@gmsh -2 circle.geo
@@ -32,31 +28,78 @@ uniform_square:
 	@python3 run_fixed_mesh.py -geometry square -level 3
 	@python3 run_fixed_mesh.py -geometry square -level 4
 
-print_circle:
+print_uniform_circle:
 	@cat outputs/fixed_mesh/circle_1.log
 	@cat outputs/fixed_mesh/circle_2.log
 	@cat outputs/fixed_mesh/circle_4.log
 	@cat outputs/fixed_mesh/circle_8.log
 	@cat outputs/fixed_mesh/circle_16.log
 
-print_square:
+print_uniform_square:
 	@cat outputs/fixed_mesh/square_1.log
 	@cat outputs/fixed_mesh/square_2.log
 	@cat outputs/fixed_mesh/square_4.log
 	@cat outputs/fixed_mesh/square_8.log
 	@cat outputs/fixed_mesh/square_16.log
 
-plot: plot_circle plot_square
+plot_uniform: plot_uniform_circle plot_uniform_square
 
-plot_circle:
+plot_uniform_circle:
 	@echo "Plotting convergence for circular domain..."
 	@python3 plot_convergence.py -geometry circle
 	@gio open outputs/fixed_mesh/convergence_circle.pdf
 
-plot_square:
+plot_uniform_square:
 	@echo "Plotting convergence for square domain..."
 	@python3 plot_convergence.py -geometry square
 	@gio open outputs/fixed_mesh/convergence_square.pdf
+
+
+# --- Lagrangian convergence
+
+lagrangian: lagrangian_circle lagrangian_square
+
+lagrangian_circle:
+	@echo "Solving solid body rotation problem on circular domain..."
+	@python3 run_lagrangian.py -geometry circle -level 0
+	@python3 run_lagrangian.py -geometry circle -level 1
+	@python3 run_lagrangian.py -geometry circle -level 2
+	@python3 run_lagrangian.py -geometry circle -level 3
+	@python3 run_lagrangian.py -geometry circle -level 4
+
+lagrangian_square:
+	@echo "Solving solid body rotation problem on square domain..."
+	@python3 run_lagrangian.py -geometry square -level 0
+	@python3 run_lagrangian.py -geometry square -level 1
+	@python3 run_lagrangian.py -geometry square -level 2
+	@python3 run_lagrangian.py -geometry square -level 3
+	@python3 run_lagrangian.py -geometry square -level 4
+
+print_lagrangian_circle:
+	@cat outputs/lagrangian/circle_1.log
+	@cat outputs/lagrangian/circle_2.log
+	@cat outputs/lagrangian/circle_4.log
+	@cat outputs/lagrangian/circle_8.log
+	@cat outputs/lagrangian/circle_16.log
+
+print_lagrangian_square:
+	@cat outputs/lagrangian/square_1.log
+	@cat outputs/lagrangian/square_2.log
+	@cat outputs/lagrangian/square_4.log
+	@cat outputs/lagrangian/square_8.log
+	@cat outputs/lagrangian/square_16.log
+
+plot_lagrangian: plot_lagrangian_circle plot_lagrangian_square
+
+plot_lagrangian_circle:
+	@echo "Plotting Lagrangian convergence for circular domain..."
+	@python3 plot_convergence.py -geometry circle -approach lagrangian
+	@gio open outputs/lagrangian/convergence_circle.pdf
+
+plot_lagrangian_square:
+	@echo "Plotting Lagrangian convergence for square domain..."
+	@python3 plot_convergence.py -geometry square -approach lagrangian
+	@gio open outputs/lagrangian/convergence_square.pdf
 
 
 # --- Cleanup

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -22,6 +22,7 @@ uniform_circle:
 	@python3 run_fixed_mesh.py -geometry circle -level 1
 	@python3 run_fixed_mesh.py -geometry circle -level 2
 	@python3 run_fixed_mesh.py -geometry circle -level 3
+	@python3 run_fixed_mesh.py -geometry circle -level 4
 
 uniform_square:
 	@echo "Solving solid body rotation problem on square domain..."
@@ -29,18 +30,21 @@ uniform_square:
 	@python3 run_fixed_mesh.py -geometry square -level 1
 	@python3 run_fixed_mesh.py -geometry square -level 2
 	@python3 run_fixed_mesh.py -geometry square -level 3
+	@python3 run_fixed_mesh.py -geometry square -level 4
 
 print_circle:
 	@cat outputs/fixed_mesh/circle_1.log
 	@cat outputs/fixed_mesh/circle_2.log
 	@cat outputs/fixed_mesh/circle_4.log
 	@cat outputs/fixed_mesh/circle_8.log
+	@cat outputs/fixed_mesh/circle_16.log
 
 print_square:
 	@cat outputs/fixed_mesh/square_1.log
 	@cat outputs/fixed_mesh/square_2.log
 	@cat outputs/fixed_mesh/square_4.log
 	@cat outputs/fixed_mesh/square_8.log
+	@cat outputs/fixed_mesh/square_16.log
 
 plot: plot_circle plot_square
 

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -18,17 +18,17 @@ uniform: uniform_circle uniform_square
 
 uniform_circle:
 	@echo "Solving solid body rotation problem on circular domain..."
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 0
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 1
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 2
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 3
+	@python3 run_fixed_mesh.py -geometry circle -level 0
+	@python3 run_fixed_mesh.py -geometry circle -level 1
+	@python3 run_fixed_mesh.py -geometry circle -level 2
+	@python3 run_fixed_mesh.py -geometry circle -level 3
 
 uniform_square:
 	@echo "Solving solid body rotation problem on square domain..."
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 0
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 1
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 2
-	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 3
+	@python3 run_fixed_mesh.py -geometry square -level 0
+	@python3 run_fixed_mesh.py -geometry square -level 1
+	@python3 run_fixed_mesh.py -geometry square -level 2
+	@python3 run_fixed_mesh.py -geometry square -level 3
 
 print_circle:
 	@cat outputs/fixed_mesh/circle_1.log
@@ -46,12 +46,12 @@ plot: plot_circle plot_square
 
 plot_circle:
 	@echo "Plotting convergence for circular domain..."
-	@python3 plot_convergence.py -mesh_type circle
+	@python3 plot_convergence.py -geometry circle
 	@gio open outputs/fixed_mesh/convergence_circle.pdf
 
 plot_square:
 	@echo "Plotting convergence for square domain..."
-	@python3 plot_convergence.py -mesh_type square
+	@python3 plot_convergence.py -geometry square
 	@gio open outputs/fixed_mesh/convergence_square.pdf
 
 

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -19,6 +19,7 @@ uniform_circle:
 	@python3 run_fixed_mesh.py -geometry circle -level 2
 	@python3 run_fixed_mesh.py -geometry circle -level 3
 	@python3 run_fixed_mesh.py -geometry circle -level 4
+	@python3 run_fixed_mesh.py -geometry circle -level 5
 
 uniform_square:
 	@echo "Solving solid body rotation problem on square domain..."
@@ -27,6 +28,7 @@ uniform_square:
 	@python3 run_fixed_mesh.py -geometry square -level 2
 	@python3 run_fixed_mesh.py -geometry square -level 3
 	@python3 run_fixed_mesh.py -geometry square -level 4
+	@python3 run_fixed_mesh.py -geometry square -level 5
 
 print_uniform_circle:
 	@cat outputs/fixed_mesh/circle_1.log
@@ -34,6 +36,7 @@ print_uniform_circle:
 	@cat outputs/fixed_mesh/circle_4.log
 	@cat outputs/fixed_mesh/circle_8.log
 	@cat outputs/fixed_mesh/circle_16.log
+	@cat outputs/fixed_mesh/circle_32.log
 
 print_uniform_square:
 	@cat outputs/fixed_mesh/square_1.log
@@ -41,6 +44,7 @@ print_uniform_square:
 	@cat outputs/fixed_mesh/square_4.log
 	@cat outputs/fixed_mesh/square_8.log
 	@cat outputs/fixed_mesh/square_16.log
+	@cat outputs/fixed_mesh/square_32.log
 
 plot_uniform: plot_uniform_circle plot_uniform_square
 
@@ -66,6 +70,7 @@ lagrangian_circle:
 	@python3 run_lagrangian.py -geometry circle -level 2
 	@python3 run_lagrangian.py -geometry circle -level 3
 	@python3 run_lagrangian.py -geometry circle -level 4
+	@python3 run_lagrangian.py -geometry circle -level 5
 
 lagrangian_square:
 	@echo "Solving solid body rotation problem on square domain..."
@@ -74,6 +79,7 @@ lagrangian_square:
 	@python3 run_lagrangian.py -geometry square -level 2
 	@python3 run_lagrangian.py -geometry square -level 3
 	@python3 run_lagrangian.py -geometry square -level 4
+	@python3 run_lagrangian.py -geometry square -level 5
 
 print_lagrangian_circle:
 	@cat outputs/lagrangian/circle_1.log
@@ -81,6 +87,7 @@ print_lagrangian_circle:
 	@cat outputs/lagrangian/circle_4.log
 	@cat outputs/lagrangian/circle_8.log
 	@cat outputs/lagrangian/circle_16.log
+	@cat outputs/lagrangian/circle_32.log
 
 print_lagrangian_square:
 	@cat outputs/lagrangian/square_1.log
@@ -88,6 +95,7 @@ print_lagrangian_square:
 	@cat outputs/lagrangian/square_4.log
 	@cat outputs/lagrangian/square_8.log
 	@cat outputs/lagrangian/square_16.log
+	@cat outputs/lagrangian/square_32.log
 
 plot_lagrangian: plot_lagrangian_circle plot_lagrangian_square
 

--- a/unsteady/test_cases/solid_body_rotation/makefile
+++ b/unsteady/test_cases/solid_body_rotation/makefile
@@ -1,5 +1,6 @@
 all: clean mesh
 
+
 # --- Mesh
 
 circle: uniform_circle plot_circle print_circle
@@ -10,23 +11,24 @@ mesh:
 	@echo "Generating Delauney mesh of circular domain..."
 	@gmsh -2 circle.geo
 
+
 # --- Uniform convergence
 
 uniform: uniform_circle uniform_square
 
 uniform_circle:
 	@echo "Solving solid body rotation problem on circular domain..."
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 0
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 1
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 2
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type circle -init_res 3
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 0
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 1
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 2
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type circle -level 3
 
 uniform_square:
 	@echo "Solving solid body rotation problem on square domain..."
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 0
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 1
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 2
-	@python3 run_thetis.py -approach fixed_mesh -mesh_type square -init_res 3
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 0
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 1
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 2
+	@python3 run_fixed_mesh.py -approach fixed_mesh -mesh_type square -level 3
 
 print_circle:
 	@cat outputs/fixed_mesh/circle_1.log
@@ -51,6 +53,7 @@ plot_square:
 	@echo "Plotting convergence for square domain..."
 	@python3 plot_convergence.py -mesh_type square
 	@gio open outputs/fixed_mesh/convergence_square.pdf
+
 
 # --- Cleanup
 

--- a/unsteady/test_cases/solid_body_rotation/options.py
+++ b/unsteady/test_cases/solid_body_rotation/options.py
@@ -28,7 +28,7 @@ class LeVequeOptions(CoupledOptions):
     The QoI considered in this test case may be viewed as an extension of the QoI considered in the
     [Power et al. 2006] and TELEMAC-2D test cases to time-dependent problems.
     """
-    def __init__(self, shape=0, geometry='circle', n=0, background_concentration=0.0, **kwargs):
+    def __init__(self, shape=0, geometry='circle', level=0, background_concentration=0.0, **kwargs):
         self.solve_swe = False
         self.solve_tracer = True
         self.shape = shape
@@ -49,10 +49,10 @@ class LeVequeOptions(CoupledOptions):
                 self.default_mesh = Mesh(mesh_file)
             else:
                 raise IOError("Mesh file {:s} does not exist.".format(mesh_file))
-            if n > 0:
-                self.default_mesh = MeshHierarchy(self.default_mesh, n)[-1]
+            if level > 0:
+                self.default_mesh = MeshHierarchy(self.default_mesh, level)[-1]
         elif geometry == 'square':
-            self.default_mesh = UnitSquareMesh(40*2**n, 40*2**n)
+            self.default_mesh = UnitSquareMesh(40*2**level, 40*2**level)
         else:
             raise ValueError("Geometry {:s} not recognised.".format(geometry))
         self.default_mesh.coordinates.dat.data[:] -= 0.5

--- a/unsteady/test_cases/solid_body_rotation/plot_convergence.py
+++ b/unsteady/test_cases/solid_body_rotation/plot_convergence.py
@@ -5,7 +5,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-approach", help="Choose adaptive approach")
-parser.add_argument("-mesh_type", help="Choose from 'circle' or 'square'")
+parser.add_argument("-geometry", help="Choose from 'circle' or 'square'")
 args = parser.parse_args()
 
 plt.rc('text', usetex=True)
@@ -14,7 +14,7 @@ fontsize = 18
 legend_fontsize = 16
 kwargs = {'linestyle': '--', 'marker': 'x'}
 
-mesh_type = args.mesh_type or 'circle'
+geometry = args.geometry or 'circle'
 approach = args.approach or 'fixed_mesh'
 
 shapes = ('Gaussian', 'Cone', 'Slotted Cylinder')
@@ -25,7 +25,7 @@ dat = {}
 for shape in shapes:
     dat[shape] = {'qois': [], 'errors': []}
 for n in (1, 2, 4, 8):
-    with open(os.path.join('outputs', approach, '{:s}_{:d}.log'.format(mesh_type, n)), 'r') as f:
+    with open(os.path.join('outputs', approach, '{:s}_{:d}.log'.format(geometry, n)), 'r') as f:
         f.readline()
         f.readline()
         f.readline()
@@ -55,4 +55,4 @@ format_spec = lambda l: r"{:.3f}\%".format(l) if l < 1.0 else r"{:.1f}\%".format
 ax.set_yticklabels([format_spec(l) for l in ax.get_yticks().tolist()])
 plt.legend(fontsize=legend_fontsize)
 plt.tight_layout()
-plt.savefig(os.path.join('outputs', approach, 'convergence_{:s}.pdf'.format(mesh_type)))
+plt.savefig(os.path.join('outputs', approach, 'convergence_{:s}.pdf'.format(geometry)))

--- a/unsteady/test_cases/solid_body_rotation/run_adjoint.py
+++ b/unsteady/test_cases/solid_body_rotation/run_adjoint.py
@@ -38,7 +38,7 @@ kwargs = {
     'geometry': geometry,
 
     # Spatial discretisation
-    'refinement_level': i,
+    'level': i,
     'tracer_family': args.family or 'dg',
     'stabilisation': args.stabilisation,
     'use_automatic_sipg_parameter': False,  # We have an inviscid problem

--- a/unsteady/test_cases/solid_body_rotation/run_fixed_mesh.py
+++ b/unsteady/test_cases/solid_body_rotation/run_fixed_mesh.py
@@ -35,7 +35,7 @@ kwargs = {
     'geometry': geometry,
 
     # Spatial discretisation
-    'refinement_level': i,
+    'level': i,
     'tracer_family': args.family or 'dg',
     'stabilisation': args.stabilisation,
     'use_automatic_sipg_parameter': False,  # We have an inviscid problem

--- a/unsteady/test_cases/solid_body_rotation/run_fixed_mesh.py
+++ b/unsteady/test_cases/solid_body_rotation/run_fixed_mesh.py
@@ -65,16 +65,18 @@ tp.solve_forward()
 
 # Print outputs
 f = open(os.path.join(tp.di, "{:s}_{:d}.log".format(geometry, n)), 'w+')
-head = "\n  Shape            Analytic QoI    Quadrature QoI  Calculated QoI  Error"
-rule = 74*'='
+head = "\n  Shape            Analytic QoI    Quadrature QoI  Calculated QoI  Error    Disc. error"
+rule = 90*'='
 write(head, f)
 write(rule, f)
 for shape, name in zip(range(3), ('Gaussian', 'Cone', 'Slotted cylinder')):
-    op.shape = shape
-    exact = op.exact_qoi()
+    op.set_region_of_interest(shape)
+    tp.op.set_qoi_kernel_tracer(tp, -1)
     qoi = tp.quantity_of_interest()
-    qois = (exact, op.quadrature_qoi(tp, -1), qoi, 100.0*abs(1.0 - qoi/exact))
-    line = "{:1d} {:16s} {:14.8e}  {:14.8e}  {:14.8e}  {:6.4f}%".format(shape, name, *qois)
+    exact = op.exact_qoi()
+    quadrature = op.quadrature_qoi(tp, -1)
+    qois = (exact, quadrature, qoi, 100*abs(1.0 - qoi/exact), 100*abs(1.0 - qoi/quadrature))
+    line = "{:1d} {:16s} {:14.8e}  {:14.8e}  {:14.8e}  {:6.4f}%  {:6.4f}%".format(shape, name, *qois)
     write(line, f)
 write(rule, f)
 approach = "'" + tp.approach.replace('_', ' ').capitalize() + "'"

--- a/unsteady/test_cases/solid_body_rotation/run_lagrangian.py
+++ b/unsteady/test_cases/solid_body_rotation/run_lagrangian.py
@@ -35,7 +35,7 @@ kwargs = {
     'geometry': geometry,
 
     # Spatial discretisation
-    'refinement_level': i,
+    'level': i,
     'tracer_family': args.family or 'dg',
     'stabilisation': args.stabilisation,
     'use_automatic_sipg_parameter': False,  # We have an inviscid problem


### PR DESCRIPTION
Various updates for the classic advection test case, allowing convergence plots like this one for volume conservation of the solid bodies.

![convergence_circle](https://user-images.githubusercontent.com/22053413/95965675-1a5da400-0e02-11eb-86a1-e5ad0ce87950.png)

Also adds a warning in case `SinkTerm` isn't defined.